### PR TITLE
[Feat] 주문 도메인 전체 API 명세 및 DTO 작성

### DIFF
--- a/src/main/java/com/dfdt/delivery/DeliciousFoodDeliveryApplication.java
+++ b/src/main/java/com/dfdt/delivery/DeliciousFoodDeliveryApplication.java
@@ -2,7 +2,9 @@ package com.dfdt.delivery;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class DeliciousFoodDeliveryApplication {
 

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandService.java
@@ -1,4 +1,5 @@
 package com.dfdt.delivery.domain.order.application.service.command;
 
-public interface OrderCommandService {
+@service
+public class OrderCommandService {
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandService.java
@@ -1,0 +1,4 @@
+package com.dfdt.delivery.domain.order.application.service.command;
+
+public interface OrderCommandService {
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/query/OrderQueryService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/query/OrderQueryService.java
@@ -1,0 +1,4 @@
+package com.dfdt.delivery.domain.order.application.service.query;
+
+public interface OrderQueryService {
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/query/OrderQueryService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/query/OrderQueryService.java
@@ -1,4 +1,7 @@
 package com.dfdt.delivery.domain.order.application.service.query;
 
-public interface OrderQueryService {
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderQueryService {
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderRepository.java
@@ -1,9 +1,4 @@
 package com.dfdt.delivery.domain.order.domain.repository;
 
-import com.dfdt.delivery.domain.order.domain.entity.Order;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.UUID;
-
-public interface OrderRepository extends JpaRepository<Order, UUID> {
+public interface OrderRepository {
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/JpaOrderRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/JpaOrderRepository.java
@@ -1,0 +1,10 @@
+package com.dfdt.delivery.domain.order.infrastructure.persistence.repository;
+
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface JpaOrderRepository extends JpaRepository<Order, UUID> , OrderRepository {
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
@@ -5,7 +5,6 @@ import com.dfdt.delivery.domain.order.application.service.query.OrderQueryServic
 import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
 import com.dfdt.delivery.domain.order.application.service.command.OrderCommandService;
-import com.dfdt.delivery.domain.order.application.service.query.OrderQueryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
@@ -77,7 +77,7 @@ public class OrderController implements OrderControllerDocs {
     // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
 
     // API-005 주문 삭제하기
-    @DeleteMapping("/{order_id}/delete/{user_id}")
+    @DeleteMapping("/{order_id}/{user_id}")
     public ResponseEntity<ApiResponseDto<Void>> deleteOrder(
             @PathVariable (value = "order_id") String orderId,
             @PathVariable (value = "user_id") String  userId
@@ -90,35 +90,7 @@ public class OrderController implements OrderControllerDocs {
     }
     // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
 
-    // API-006 주문 수락하기
-    @PatchMapping("/{order_id}/accept/{user_id}")
-    public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> acceptOrder(
-            @PathVariable (value = "order_id") String orderId,
-            @PathVariable (value = "user_id") String  userId
-    ) {
-        return ApiResponseDto.success(
-                200,
-                "주문이 수락되었습니다.",
-                null
-        );
-    }
-    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
-
-    // API-007 주문 거절하기
-    @PatchMapping("/{order_id}/reject/{user_id}")
-    public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> rejectOrder(
-            @PathVariable (value = "order_id") String orderId,
-            @PathVariable (value = "user_id") String  userId
-    ) {
-        return ApiResponseDto.success(
-                200,
-                "주문이 거절되었습니다.",
-                null
-        );
-    }
-    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
-
-    // API-008 주문 상태 변경하기
+    // API-006 주문 상태 변경하기
     @PatchMapping("/{order_id}/status/{user_id}")
     public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrderStatus(
             @PathVariable (value = "order_id") String orderId,
@@ -133,7 +105,7 @@ public class OrderController implements OrderControllerDocs {
     }
     // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
 
-    // API-009 가게의 주문 목록 조회하기 ( 상태별 )
+    // API-007 가게의 주문 목록 조회하기 ( 상태별 )
     @GetMapping("/store/{store_id}")
     public ResponseEntity<ApiResponseDto<OrderResDto.OwnerDashboardResponse>> getOrdersByOwner(
             @PathVariable (value = "store_id") String  storeId

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
@@ -5,6 +5,7 @@ import com.dfdt.delivery.domain.order.application.service.query.OrderQueryServic
 import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
 import com.dfdt.delivery.domain.order.application.service.command.OrderCommandService;
+import com.dfdt.delivery.domain.order.application.service.query.OrderQueryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
@@ -62,7 +62,7 @@ public class OrderController implements OrderControllerDocs {
     // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
 
     // API-004 주문 수정하기
-    @PatchMapping("/{order_id}/update/{user_id}")
+    @PatchMapping("/{order_id}/{user_id}")
     public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrder(
             @PathVariable (value = "order_id") String orderId,
             @PathVariable (value = "user_id") String  userId,

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
@@ -1,0 +1,147 @@
+package com.dfdt.delivery.domain.order.presentation.controller;
+
+import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.order.application.service.query.OrderQueryService;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
+import com.dfdt.delivery.domain.order.application.service.command.OrderCommandService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/orders")
+public class OrderController implements OrderControllerDocs {
+    private final OrderCommandService orderCommandService;
+    private final OrderQueryService orderQueryService;
+
+    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
+
+    // API-001 주문 생성하기
+    @PostMapping("/{user_id}")
+    public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> createOrder(
+            @PathVariable (value = "user_id") String userId,
+            @Valid @RequestBody  OrderReqDto.Create createDTO)
+    {
+        return ApiResponseDto.success(
+                201,
+                "주문이 생성되었습니다.",
+                null
+        );
+    }
+    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
+
+    // API-002 사용자의 주문 목록 조회
+    @GetMapping("/{user_id}")
+    public ResponseEntity<ApiResponseDto<OrderResDto.CustomerOrderResponse>> getOrders(
+            @PathVariable (value = "user_id") String userId
+    ){
+        return ApiResponseDto.success(
+                200,
+                "사용자의 주문 목록을 조회하였습니다.",
+                null
+        );
+    }
+    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
+
+    // API-003 주문 상세 조회
+    @GetMapping("/{order_id}/{user_id}")
+    public ResponseEntity<ApiResponseDto<OrderResDto.GetOrderDetailResponse>> getOrderDetail(
+            @PathVariable (value = "order_id") String orderId,
+            @PathVariable (value = "user_id") String  userId
+    ){
+        return ApiResponseDto.success(
+                200,
+                "해당 주문을 조회하였습니다.",
+                null
+        );
+    }
+    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
+
+    // API-004 주문 수정하기
+    @PatchMapping("/{order_id}/update/{user_id}")
+    public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrder(
+            @PathVariable (value = "order_id") String orderId,
+            @PathVariable (value = "user_id") String  userId,
+            @Valid @RequestBody OrderReqDto.UpdateOrder updateDTO
+    ) {
+        return ApiResponseDto.success(
+                200,
+                "주문이 수정되었습니다.",
+                null
+        );
+    }
+    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
+
+    // API-005 주문 삭제하기
+    @DeleteMapping("/{order_id}/delete/{user_id}")
+    public ResponseEntity<ApiResponseDto<Void>> deleteOrder(
+            @PathVariable (value = "order_id") String orderId,
+            @PathVariable (value = "user_id") String  userId
+    ) {
+        return ApiResponseDto.success(
+                200,
+                "주문이 삭제되었습니다.",
+                null
+        );
+    }
+    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
+
+    // API-006 주문 수락하기
+    @PatchMapping("/{order_id}/accept/{user_id}")
+    public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> acceptOrder(
+            @PathVariable (value = "order_id") String orderId,
+            @PathVariable (value = "user_id") String  userId
+    ) {
+        return ApiResponseDto.success(
+                200,
+                "주문이 수락되었습니다.",
+                null
+        );
+    }
+    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
+
+    // API-007 주문 거절하기
+    @PatchMapping("/{order_id}/reject/{user_id}")
+    public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> rejectOrder(
+            @PathVariable (value = "order_id") String orderId,
+            @PathVariable (value = "user_id") String  userId
+    ) {
+        return ApiResponseDto.success(
+                200,
+                "주문이 거절되었습니다.",
+                null
+        );
+    }
+    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
+
+    // API-008 주문 상태 변경하기
+    @PatchMapping("/{order_id}/status/{user_id}")
+    public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrderStatus(
+            @PathVariable (value = "order_id") String orderId,
+            @PathVariable (value = "user_id") String  userId,
+            @Valid @RequestBody OrderReqDto.UpdateStatus updateStatusDTO
+    ) {
+        return ApiResponseDto.success(
+                200,
+                "주문 상태가 성공적으로 변경되었습니다.",
+                null
+        );
+    }
+    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
+
+    // API-009 가게의 주문 목록 조회하기 ( 상태별 )
+    @GetMapping("/store/{store_id}")
+    public ResponseEntity<ApiResponseDto<OrderResDto.OwnerDashboardResponse>> getOrdersByOwner(
+            @PathVariable (value = "store_id") String  storeId
+    ) {
+        return ApiResponseDto.success(
+                200,
+                "가게의 주문 목록이 조회되었습니다.",
+                null
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
@@ -102,44 +102,8 @@ public interface OrderControllerDocs {
             @PathVariable(value = "user_id") String userId);
 
 
-    @Operation(summary = "API-006 주문 수락하기", description = "사장님이 접수된 주문을 수락하여 조리를 시작합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "수락 성공"),            
-            @ApiResponse(responseCode = "400", description = "잘못된 주문 요청", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "이미 처리된 주문", value = OrderErrorDocs.ALREADY_PROCESSED), 
-                    @ExampleObject(name = "사용자 결제 전", value = OrderErrorDocs.PAYMENT_REQUIRED)
-            })),
-            @ApiResponse(responseCode = "401", description = "권한 오류", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
-            })),
-            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ORDER_NOT_FOUND)
-            })),
-    })
-    ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> acceptOrder(
-            @PathVariable(value = "order_id") String orderId,
-            @PathVariable(value = "user_id") String userId);
-
-
-    @Operation(summary = "API-007 주문 거절하기", description = "재고 부족 등의 사유로 사장님이 주문을 거절합니다.")
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "거절 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 주문 요청", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "이미 처리된 주문", value = OrderErrorDocs.ALREADY_PROCESSED)
-            })),
-            @ApiResponse(responseCode = "401", description = "권한 오류", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
-            })),
-            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ORDER_NOT_FOUND)
-            })),
-    })
-    ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> rejectOrder(
-            @PathVariable(value = "order_id") String orderId,
-            @PathVariable(value = "user_id") String userId);
-
-
-    @Operation(summary = "API-008 주문 상태 변경하기", description = "준비 중 -> 배달 중 -> 배달 완료 등으로 상태를 수동 변경합니다.")
+    
+    @Operation(summary = "API-006 주문 상태 변경하기", description = "준비 중 -> 배달 중 -> 배달 완료 등으로 상태를 수동 변경합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "상태 변경 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 주문 요청", content = @Content(mediaType = "application/json", examples = {
@@ -159,7 +123,7 @@ public interface OrderControllerDocs {
     );
 
 
-    @Operation(summary = "API-009 가게의 주문 목록 조회하기", description = "가게 ID를 기준으로 들어온 모든 주문을 조회합니다.")
+    @Operation(summary = "API-007 가게의 주문 목록 조회하기", description = "가게 ID를 기준으로 들어온 모든 주문을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "404", description = "가게 정보를 찾을 수 없음")

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
@@ -56,7 +56,7 @@ public interface OrderControllerDocs {
                     @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
             })),
             @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "판매 중지 상품 포함", value = OrderErrorDocs.ORDER_NOT_FOUND)
+                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ORDER_NOT_FOUND)
             }))
     })
     ResponseEntity<ApiResponseDto<OrderResDto.GetOrderDetailResponse>> getOrderDetail(

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
@@ -74,7 +74,7 @@ public interface OrderControllerDocs {
                     @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
             })),
             @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ACCESS_DENIED)
+                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ORDER_NOT_FOUND)
             })),
     })
     ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrder(
@@ -94,7 +94,7 @@ public interface OrderControllerDocs {
                     @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
             })),
             @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ACCESS_DENIED)
+                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ORDER_NOT_FOUND)
             })),
     })
     ResponseEntity<ApiResponseDto<Void>> deleteOrder(
@@ -113,7 +113,7 @@ public interface OrderControllerDocs {
                     @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
             })),
             @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ACCESS_DENIED)
+                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ORDER_NOT_FOUND)
             })),
     })
     ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> acceptOrder(
@@ -131,7 +131,7 @@ public interface OrderControllerDocs {
                     @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
             })),
             @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ACCESS_DENIED)
+                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ORDER_NOT_FOUND)
             })),
     })
     ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> rejectOrder(
@@ -149,7 +149,7 @@ public interface OrderControllerDocs {
                     @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
             })),
             @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
-                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ACCESS_DENIED)
+                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ORDER_NOT_FOUND)
             })),
     })
     ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrderStatus(

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
@@ -1,0 +1,169 @@
+package com.dfdt.delivery.domain.order.presentation.controller;
+
+import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Order (주문)", description = "주문 생성 및 상태 관리를 담당합니다.")
+public interface OrderControllerDocs {
+
+    @Operation(summary = "API-001 주문 생성", description = "사용자가 장바구니의 상품으로 주문을 요청합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "주문 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 주문 요청", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문 수량 오류", value = OrderErrorDocs.INVALID_QUANTITY),
+                    @ExampleObject(name = "가게 상품 불일치", value = OrderErrorDocs.SHOP_MISMATCH),
+                    @ExampleObject(name = "가격 변동 발생", value = OrderErrorDocs.PRICE_CHANGED),
+                    @ExampleObject(name = "재고 부족", value = OrderErrorDocs.OUT_OF_STOCK)
+            })),
+            @ApiResponse(responseCode = "403", description = "권한 부족/판매 중지", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "판매 중지 상품 포함", value = OrderErrorDocs.PRODUCT_NOT_FOR_SALE)
+            })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "상품을 찾을 수 없음"),
+                    @ExampleObject(name = "주소를 찾을 수 없음"),
+                    @ExampleObject(name = "가게를 찾을 수 없음"),
+            })),
+    })
+    ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> createOrder(
+            @PathVariable(value = "user_id") String userId,
+            @Valid @RequestBody OrderReqDto.Create createDTO);
+
+
+    @Operation(summary = "API-002 사용자의 주문 목록 조회", description = "본인의 전체 주문 내역을 리스트 형식으로 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
+    })
+    ResponseEntity<ApiResponseDto<OrderResDto.CustomerOrderResponse>> getOrders(
+            @PathVariable(value = "user_id") String userId);
+
+
+    @Operation(summary = "API-003 주문 상세 조회", description = "특정 주문에 대한 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "권한 오류", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
+            })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "판매 중지 상품 포함", value = OrderErrorDocs.ORDER_NOT_FOUND)
+            }))
+    })
+    ResponseEntity<ApiResponseDto<OrderResDto.GetOrderDetailResponse>> getOrderDetail(
+            @PathVariable(value = "order_id") String orderId,
+            @PathVariable(value = "user_id") String userId);
+
+
+    @Operation(summary = "API-004 주문 수정하기", description = "배달지 정보나 요청사항 등 주문 내용을 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 주문 요청", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "이미 처리된 주문", value = OrderErrorDocs.ALREADY_PROCESSED)
+            })),
+            @ApiResponse(responseCode = "401", description = "권한 오류", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
+            })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ACCESS_DENIED)
+            })),
+    })
+    ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrder(
+            @PathVariable(value = "order_id") String orderId,
+            @PathVariable(value = "user_id") String userId,
+            @Valid @RequestBody OrderReqDto.UpdateOrder updateDTO
+    );
+
+
+    @Operation(summary = "API-005 주문 삭제하기", description = "주문을 취소하고 내역에서 삭제(Soft Delete)합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 주문 요청", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "이미 처리된 주문", value = OrderErrorDocs.ALREADY_PROCESSED)
+            })),
+            @ApiResponse(responseCode = "401", description = "권한 오류", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
+            })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ACCESS_DENIED)
+            })),
+    })
+    ResponseEntity<ApiResponseDto<Void>> deleteOrder(
+            @PathVariable(value = "order_id") String orderId,
+            @PathVariable(value = "user_id") String userId);
+
+
+    @Operation(summary = "API-006 주문 수락하기", description = "사장님이 접수된 주문을 수락하여 조리를 시작합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수락 성공"),            
+            @ApiResponse(responseCode = "400", description = "잘못된 주문 요청", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "이미 처리된 주문", value = OrderErrorDocs.ALREADY_PROCESSED), 
+                    @ExampleObject(name = "사용자 결제 전", value = OrderErrorDocs.PAYMENT_REQUIRED)
+            })),
+            @ApiResponse(responseCode = "401", description = "권한 오류", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
+            })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ACCESS_DENIED)
+            })),
+    })
+    ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> acceptOrder(
+            @PathVariable(value = "order_id") String orderId,
+            @PathVariable(value = "user_id") String userId);
+
+
+    @Operation(summary = "API-007 주문 거절하기", description = "재고 부족 등의 사유로 사장님이 주문을 거절합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "거절 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 주문 요청", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "이미 처리된 주문", value = OrderErrorDocs.ALREADY_PROCESSED)
+            })),
+            @ApiResponse(responseCode = "401", description = "권한 오류", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
+            })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ACCESS_DENIED)
+            })),
+    })
+    ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> rejectOrder(
+            @PathVariable(value = "order_id") String orderId,
+            @PathVariable(value = "user_id") String userId);
+
+
+    @Operation(summary = "API-008 주문 상태 변경하기", description = "준비 중 -> 배달 중 -> 배달 완료 등으로 상태를 수동 변경합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "상태 변경 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 주문 요청", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "이미 처리된 주문", value = OrderErrorDocs.ALREADY_PROCESSED)
+            })),
+            @ApiResponse(responseCode = "401", description = "권한 오류", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문에 접근 권한 없음", value = OrderErrorDocs.ACCESS_DENIED)
+            })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문을 찾을 수 없음", value = OrderErrorDocs.ACCESS_DENIED)
+            })),
+    })
+    ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrderStatus(
+            @PathVariable(value = "order_id") String orderId,
+            @PathVariable(value = "user_id") String userId,
+            @Valid @RequestBody OrderReqDto.UpdateStatus updateStatusDTO
+    );
+
+
+    @Operation(summary = "API-009 가게의 주문 목록 조회하기", description = "가게 ID를 기준으로 들어온 모든 주문을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "가게 정보를 찾을 수 없음")
+    })
+    ResponseEntity<ApiResponseDto<OrderResDto.OwnerDashboardResponse>> getOrdersByOwner(
+            @PathVariable(value = "store_id") String store_id);
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderErrorDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderErrorDocs.java
@@ -1,0 +1,33 @@
+package com.dfdt.delivery.domain.order.presentation.controller;
+
+public class OrderErrorDocs {
+    // --- 400 Bad Request ---
+    public static final String INVALID_QUANTITY = """
+        { "status": 400, "code": "ORDER-4000", "message": "주문 수량은 1개 이상이어야 합니다." }""";
+
+    public static final String SHOP_MISMATCH = """
+        { "status": 400, "code": "ORDER-4001", "message": "해당 가게의 상품이 아닙니다." }""";
+
+    public static final String ALREADY_PROCESSED = """
+        { "status": 400, "code": "ORDER-4002", "message": "이미 처리된 주문건입니다." }""";
+
+    public static final String PAYMENT_REQUIRED = """
+        { "status": 400, "code": "ORDER-4003", "message": "사용자가 결제를 하지 않았습니다." }""";
+
+    public static final String PRICE_CHANGED = """
+        { "status": 400, "code": "ORDER-4004", "message": "상품의 가격이 변동되었습니다. 다시 확인해 주세요." }""";
+
+    public static final String OUT_OF_STOCK = """
+        { "status": 400, "code": "ORDER-4005", "message": "재고가 부족합니다." }""";
+
+    // --- 401 Unauthorized / 403 Forbidden ---
+    public static final String ACCESS_DENIED = """
+        { "status": 401, "code": "ORDER-4010", "message": "해당 주문에 대해 접근할 수 있는 권한이 없습니다." }""";
+
+    public static final String PRODUCT_NOT_FOR_SALE = """
+        { "status": 403, "code": "ORDER-4031", "message": "현재 판매 중이 아닌 상품이 포함되어 있습니다." }""";
+
+    // --- 404 Not Found ---
+    public static final String ORDER_NOT_FOUND = """
+        { "status": 404, "code": "ORDER-4040", "message": "주문을 찾을 수 없습니다." }""";
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
@@ -13,7 +13,7 @@ public class OrderReqDto {
             UUID storeId,
             @NotNull(message = "주소가 입력되지 않았습니다.")
             UUID addressId,
-            @NotNull @NotEmpty(message = "하나 이상의 상품이 들어있어야 합니다.")
+            @NotEmpty(message = "하나 이상의 상품이 들어있어야 합니다.")
             List<OrderItem> productItemList,
             @Length(max = 255,message = "최대 255자 입니다.")
             String requestMemo

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
@@ -1,0 +1,40 @@
+package com.dfdt.delivery.domain.order.presentation.dto;
+
+import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
+import jakarta.validation.constraints.*;
+import org.hibernate.validator.constraints.Length;
+
+import java.util.List;
+import java.util.UUID;
+
+public class OrderReqDto {
+    public record Create(
+            @NotNull(message = "가게 아이디가 입력되지 않았습니다.")
+            UUID storeId,
+            @NotNull(message = "주소가 입력되지 않았습니다.")
+            UUID addressId,
+            @NotNull @NotEmpty(message = "하나 이상의 상품이 들어있어야 합니다.")
+            List<OrderItem> productItemList,
+            @Length(max = 255,message = "최대 255자 입니다.")
+            String requestMemo
+    ){}
+    public record OrderItem(
+            @NotNull(message = "상품 아이디가 입력되지 않았습니다.")
+            UUID productId,
+            @NotNull(message = "상품 수량이 입력되지 않았습니다.")
+            Integer quantity,
+            @NotNull(message = "상품 가격이 입력되지 않았습니다.")
+            Long userViewedUnitPrice
+    ){}
+    public record UpdateOrder(
+            UUID addressId,
+            List<OrderItem> orderItems,
+            @Length(max = 255,message = "최대 255자 입니다.")
+            String requestMemo
+    ){}
+    public record UpdateStatus(
+            @NotNull(message = "상태가 입력되지 않았습니다.")
+            OrderStatus orderStatus,
+            String changedReason
+    ){}
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderResDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderResDto.java
@@ -1,0 +1,117 @@
+package com.dfdt.delivery.domain.order.presentation.dto;
+
+import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
+import lombok.Builder;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public class OrderResDto {
+
+    // 사용자용 GET
+    @Builder
+    public record CustomerOrderResponse(
+            List<CustomerOrderSummary> orderList,
+            PaginationInfo pagination
+    ){}
+
+    @Builder
+    public record CustomerOrderSummary(
+            UUID orderId,
+            UUID orderStoreId,
+            String orderStoreName,
+            OffsetDateTime orderedAt,
+            Long totalPrice,
+            Integer totalQuantity,
+            String representativeProductName,
+            String orderAddress,
+            OrderStatus orderStatus
+    ){}
+
+    // 가게용 GET
+    @Builder
+    public record OwnerDashboardResponse(
+            OrderSummaryCount summary,
+            Map<OrderStatus, List<OwnerOrderUnit>> statusGroups,
+            PaginationInfo pagination
+    ){}
+
+    @Builder
+    public record OrderSummaryCount(
+            long pendingCount,
+            long paidCount,
+            long cookingCount,
+            long doneCount,
+            long canceledCount
+    ){}
+
+    @Builder
+    public record OwnerOrderUnit(
+            UUID orderId,
+            OffsetDateTime orderTime,
+            Long totalPrice,
+            Integer totalQuantity,
+            String orderAddress,
+            List<ProductSimpleInfo> products
+    ){}
+
+    // 주문 상세 정보
+    @Builder
+    public record GetOrderDetailResponse(
+            UUID orderId,
+            UUID orderStoreId,
+            String orderStoreName,
+            OffsetDateTime orderedAt,
+            Long totalPrice,
+            Integer totalQuantity,
+            String orderAddress,
+            OrderStatus orderStatus,
+            List<OrderItemDetail> orderItemDetails,
+            List<OrderStatusHistoryDetail> orderStatusHistoryDetails
+    ){}
+
+    @Builder
+    public record OrderItemDetail(
+            UUID productId,
+            String productName,
+            Integer quantity,
+            Long unitPrice,
+            Long totalPrice
+    ){}
+
+    @Builder
+    public record OrderStatusHistoryDetail(
+            UUID orderStatusHistoryId,
+            OrderStatus fromStatus,
+            OrderStatus nowStatus,
+            String changedReason,
+            OffsetDateTime changedAt
+    ){}
+
+    @Builder
+    public record ProductSimpleInfo(
+            UUID productId,
+            String productName
+    ){}
+    
+    // 생성 / 수정 공통 응답
+    @Builder
+    public record OrderMutationResponse(
+            UUID orderId,
+            OrderStatus orderStatus,
+            String orderAddress,
+            Long totalPrice,
+            List<OrderItemDetail> items, // 상세 수정 시에만 포함, 그 외엔 null/empty
+            OffsetDateTime updatedAt
+    ){}
+
+    // 페이징 응답
+    @Builder
+    public record PaginationInfo(
+            OffsetDateTime nextCursor,
+            Integer size,
+            boolean hasNext
+    ){}
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #2 진행중

## 📌 작업 내용
주문(Order) 도메인의 API 명세 및 데이터 구조(DTO) 정의를 완료했습니다. 현재 서비스 로직은 인터페이스 단계입니다!

## ✅ 주요 변경 사항
- **API 명세 및 문서화**: `OrderControllerDocs` 인터페이스를 분리하여 Swagger(SpringDoc) 설정을 완료하고, 각 API별 상세 성공/실패 응답 예시(`OrderErrorDocs`)를 정의했습니다.
- **도메인 DTO 설계**: 주문 생성, 상세 조회, 상태 변경 등 각 기능에 필요한 Request/Response DTO를 `record` 타입을 활용해 응답 효율성과 불변성을 확보했습니다.
- **인프라 구조 설계**: `OrderRepository` 인터페이스를 분리하고 `JpaOrderRepository`에서 상속받는 구조를 채택하여 향후 도메인 로직과 인프라 로직의 결합도를 낮췄습니다.
- **JPA Auditing 적용**: 생성/수정 시간 자동 관리를 위해 메인 애플리케이션 클래스에 `@EnableJpaAuditing`을 추가했습니다.
- **계층형 아키텍처 적용**: 커맨드(Command)와 쿼리(Query) 서비스를 분리하여 서비스 계층의 책임을 명확히 했습니다.

## 🧪 테스트 / 확인 방법
- [x] 로컬 환경 애플리케이션 빌드 및 실행 확인
- [x] Swagger UI(`/swagger-ui.html`)를 통한 API 엔드포인트 및 DTO 구조 노출 확인
- [x] Bean Validation(DTO 내 `@NotNull`, `@Length` 등) 정의 적정성 검토

### 확인 방법
1. 애플리케이션 실행 후 Swagger 페이지 접속
2. `Order (주문)` 섹션에서 정의된 9개의 API 명세가 설계서와 일치하는지 확인
3. `OrderReqDto`의 각 필드 제약 조건이 요구사항에 맞는지 검토

## ⚠️ 영향 범위
- [x] API 스펙 변경 (신규 추가)
- [ ] DB 스키마 변경
- [x] 응답값/에러코드 변경 (신규 정의)
- [x] 환경설정 변경 (JPA Auditing 활성화)
- [x] 문서(Swagger/README) 수정

## 👀 리뷰 포인트
1. **RESTful API 경로**: 현재 `userId`를 경로 변수로 받고 있습니다. `@AuthenticationPrincipal` 도입 전까지의 임시 조치인데, 경로 구성(`orders/{order_id}/...`)이 적절한지 봐주세요. 
UserPrinciple 구현되면 각 기능에서 수정할 거임!! 지금은 API 명세
2. **DTO 구조**: `OrderResDto` 내부에 내부 클래스로 응답 객체들을 관리하고 있습니다. 가독성이나 관리 측면에서 의견 부탁드립니다.
3. **Repository 구조**: 도메인 계층의 `OrderRepository`와 인프라 계층의 `JpaOrderRepository` 분리 방식이 프로젝트 전체 컨벤션과 맞는지 확인 부탁드립니다.
4. **Error 명세**: `OrderErrorDocs`에 정의된 에러 코드 포맷과 메시지가 공통 규격에 부합하는지 검토 바랍니다.