### PR TITLE
[Feat] 주문 생성/수정/삭제 기능 구현

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/order/application/converter/OrderConverter.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/converter/OrderConverter.java
@@ -1,0 +1,86 @@
+package com.dfdt.delivery.domain.order.application.converter;
+
+import com.dfdt.delivery.common.infrastructure.persistence.embedded.CreateAudit;
+import com.dfdt.delivery.common.infrastructure.persistence.embedded.UpdateAudit;
+import com.dfdt.delivery.domain.address.domain.entity.Address;
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.domain.entity.OrderItem;
+import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
+import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+
+import java.util.List;
+
+public class OrderConverter {
+
+    // DTO -> Entity
+    public static Order toOrder(User user, Address address, Store store, String requestMessage)
+    {
+        String addressSnapshot = String.format("[%s / %s] %s %s (메모: %s)",
+            address.getReceiverName(),
+            address.getReceiverPhone(),
+            address.getAddressLine1(),
+            address.getAddressLine2() != null ? address.getAddressLine2() : "",
+            address.getDeliveryMemo() != null ? address.getDeliveryMemo() : "없음"
+    );
+
+        // 엔티티 빌드 (초기화 로직 포함)
+        Order order = Order.builder()
+                .user(user)
+                .address(address)
+                .store(store)
+                .deliveryAddressSnapshot(addressSnapshot)
+                .orderRequestMessage(requestMessage)
+                .totalPrice(0)
+                .status(OrderStatus.PENDING)
+                .createdAudit(CreateAudit.now(user.getName()))
+                .updateAudit(UpdateAudit.empty())
+                .build();
+
+
+        // 초기 히스토리 추가 (이 부분만 Order 엔티티의 메서드를 호출)
+        order.getUpdateAudit().touch(user.getName());
+        order.addStatusHistory(null,OrderStatus.PENDING,"주문 생성");
+        return order;
+    }
+
+    public static OrderItem toOrderItem(Product product, Integer quantity) {
+        return OrderItem.builder()
+                .productId(product.getProductId())
+                .productNameSnapshot(product.getName())
+                .unitPriceSnapshot(product.getPrice())
+                .quantity(quantity)
+                .totalPrice(product.getPrice() * quantity)
+                .build();
+    }
+
+    // Entity -> OrderMutationResponse 변환
+    public static OrderResDto.OrderMutationResponse toMutationResponse(Order order) {
+        return OrderResDto.OrderMutationResponse.builder()
+                .orderId(order.getOrderId())
+                .orderAddress(order.getDeliveryAddressSnapshot())
+                .representativeProductName(generateOrderSummary(order.getOrderItems())) // 로직 추가
+                .totalPrice(order.getTotalPrice())
+                .orderRequestMessage(order.getOrderRequestMessage())
+                .orderStatus(order.getStatus())
+                .updatedAt(order.getUpdateAudit().getUpdatedAt())
+                .build();
+    }
+
+    // 헬퍼 메서드로 분리
+    private static String generateOrderSummary(List<OrderItem> items) {
+        if (items == null || items.isEmpty()) {
+            return "주문 항목 없음";
+        }
+
+        // 첫 번째 상품명 추출 (p_product 테이블의 name 컬럼 참조)
+        String firstProductName = items.getFirst().getProductNameSnapshot();
+        int otherCount = items.size() - 1;
+
+        return (otherCount > 0)
+                ? String.format("%s 외 %d건", firstProductName, otherCount)
+                : firstProductName;
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/application/provider/OrderDataFinder.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/provider/OrderDataFinder.java
@@ -1,0 +1,60 @@
+package com.dfdt.delivery.domain.order.application.provider;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.address.domain.entity.Address;
+import com.dfdt.delivery.domain.address.domain.repository.AddressRepository;
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.domain.enums.OrderErrorCode;
+import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
+import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.product.domain.repository.ProductRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.enums.StoreErrorCode;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.exception.error.enums.UserErrorCode;
+import com.dfdt.delivery.domain.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class OrderDataFinder {
+    private final StoreRepository storeRepository;
+    private final AddressRepository addressRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+    private final OrderRepository orderRepository;
+
+
+    public Order findOrder(UUID orderId) {
+        return orderRepository.findByIdWithLock(orderId)
+                .orElseThrow(()-> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+    }
+
+    public Store findStore(UUID storeId) {
+        return storeRepository.findById(storeId)
+                .orElseThrow(() -> new BusinessException(StoreErrorCode.NOT_FOUND_STORE));
+    }
+
+    public User findUser(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    public Address findAddress(UUID addressId) {
+        return addressRepository.findById(addressId)
+                .orElseThrow(() -> new NoSuchElementException("주소를 찾을 수 없습니다."));
+    }
+
+    public Map<UUID, Product> getProductMap(List<UUID> productIds) {
+        return productRepository.findAllById(productIds).stream()
+                .collect(Collectors.toMap(Product::getProductId, p -> p));
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/checker/OrderPreConditionChecker.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/checker/OrderPreConditionChecker.java
@@ -74,6 +74,6 @@ public class OrderPreConditionChecker {
         if (user.getRole() == UserRole.CUSTOMER) {
             authoriseOrder(order, user);
         }
-//        throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
+       throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/checker/OrderPreConditionChecker.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/checker/OrderPreConditionChecker.java
@@ -1,0 +1,79 @@
+package com.dfdt.delivery.domain.order.application.service.checker;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.domain.enums.OrderErrorCode;
+import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
+import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OrderPreConditionChecker {
+
+    public void validateProduct(Product product, Store orderStore, OrderReqDto.OrderItem itemReq) {
+        if (product == null || product.getIsHidden()) {
+            throw new BusinessException(OrderErrorCode.OUT_OF_STOCK);
+        }
+        if (itemReq.quantity() < 1) {
+            throw new BusinessException(OrderErrorCode.INVALID_QUANTITY);
+        }
+        if (!product.getStore().equals(orderStore)) {
+            throw new BusinessException(OrderErrorCode.SHOP_MISMATCH);
+        }
+        if (product.getPrice() == null ||
+                product.getPrice().compareTo(itemReq.userViewedUnitPrice()) != 0) {
+            throw new BusinessException(OrderErrorCode.PRICE_CHANGED);
+        }
+    }
+
+    public void authoriseOrder(Order order, User user) {
+        // 1. 고객인 경우: 본인 주문만 접근 가능
+        if (user.getRole() == UserRole.CUSTOMER) {
+            if (!order.getUser().getUsername().equals(user.getUsername())) {
+                throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
+            }
+        }
+        // 2. 사장님인 경우: 본인 가게의 주문만 접근 가능
+        if (user.getRole() == UserRole.OWNER) {
+            if (!order.getStore().getUser().getUsername().equals(user.getUsername())) {
+                throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
+            }
+        }
+
+        // 관리자(ADMIN)는 위 조건들에 걸리지 않으므로 모든 권한을 가짐 (자동 통과)
+    }
+    public void validateModifiable(Order order) {
+        if (order.getStatus().ordinal() >= OrderStatus.PAID.ordinal()) {
+            throw new BusinessException(OrderErrorCode.ALREADY_PROCESSED);
+        }
+    }
+    public void validateQuantity(Order order) {
+        if (order.getOrderItems().isEmpty())
+            throw new BusinessException(OrderErrorCode.INVALID_QUANTITY);
+    }
+
+    public void validateDeletable(Order order) {
+        // PAID(결제완료) 이상이면서 COMPLETED(배송완료)가 아닌 '진행 중'인 상태일 때
+        // (예: 결제완료, 상품준비중, 배송중 등)
+        if (isProcessing(order)) {
+            throw new BusinessException(OrderErrorCode.ALREADY_PROCESSED);
+        }
+    }
+    private boolean isProcessing(Order order) {
+        OrderStatus status = order.getStatus();
+        // PAID(결제완료) 보다는 크거나 같고, COMPLETED(배송완료) 보다는 작은 상태들
+        return status.ordinal() >= OrderStatus.PAID.ordinal()
+                && status.ordinal() < OrderStatus.COMPLETED.ordinal();
+    }
+
+    public void authoriseOrderCustomer(Order order, User user) {
+        if (user.getRole() == UserRole.CUSTOMER) {
+            authoriseOrder(order, user);
+        }
+//        throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandService.java
@@ -1,7 +1,11 @@
 package com.dfdt.delivery.domain.order.application.service.command;
 
-import org.springframework.stereotype.Service;
+import com.dfdt.delivery.domain.order.presentation.dto.*;
 
-@Service
-public class OrderCommandService {
+import java.util.UUID;
+
+public interface OrderCommandService {
+    OrderResDto.OrderMutationResponse createOrder(String username, OrderReqDto.Create createDTO);
+    OrderResDto.OrderMutationResponse updateOrder(String username, UUID orderId, OrderReqDto.UpdateOrder updateOrderDTO);
+    Void deleteOrder(String username, UUID orderId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandServiceImpl.java
@@ -1,0 +1,121 @@
+package com.dfdt.delivery.domain.order.application.service.command;
+
+import com.dfdt.delivery.domain.address.domain.entity.Address;
+import com.dfdt.delivery.domain.order.application.converter.OrderConverter;
+import com.dfdt.delivery.domain.order.application.provider.OrderDataFinder;
+import com.dfdt.delivery.domain.order.application.service.checker.OrderPreConditionChecker;
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.domain.entity.OrderItem;
+import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
+import com.dfdt.delivery.domain.order.domain.repository.OrderCacheManager;
+import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
+import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class OrderCommandServiceImpl implements OrderCommandService {
+    private final OrderCacheManager orderCacheManager;
+    private final OrderRepository orderRepository;
+    private final OrderPreConditionChecker orderPreConditionChecker;
+    private final OrderDataFinder orderDataFinder;
+
+
+    @Transactional
+    @Override
+    public OrderResDto.OrderMutationResponse createOrder(String username, OrderReqDto.Create createDTO) {
+        // 정보 가져오기
+        Store orderStore = orderDataFinder.findStore(createDTO.storeId());
+        Address orderAddress = orderDataFinder.findAddress(createDTO.addressId());
+        User orderUser = orderDataFinder.findUser(username);
+
+        List<UUID> productIds = createDTO.orderItems().stream().map(OrderReqDto.OrderItem::productId).toList();
+        Map<UUID, Product> stockMap = orderDataFinder.getProductMap(productIds);
+
+        // 주문 생성
+        Order order = OrderConverter.toOrder(orderUser,orderAddress,orderStore,createDTO.requestMemo());
+
+        for (OrderReqDto.OrderItem productItem : createDTO.orderItems()) {
+            Product stock = stockMap.get(productItem.productId());
+            // 매장의 상품이 존재하는 지, 재고가 있는지 확인하는 함수
+            orderPreConditionChecker.validateProduct(stock,orderStore,productItem);
+            // 주문 아이템 생성
+            OrderItem orderItem = OrderConverter.toOrderItem(stock, productItem.quantity());
+            order.addOrderItem(orderItem);
+        }
+        // DB 저장
+        Order savedOrder = orderRepository.save(order);
+        // Redis TTL 설정하여 결제 대기 시간 제한
+        orderCacheManager.setPaymentTimeout(savedOrder.getOrderId(), Duration.ofMinutes(5));
+        // 응답 반환
+        return OrderConverter.toMutationResponse(savedOrder);
+    }
+
+    @Transactional
+    @Override
+    public OrderResDto.OrderMutationResponse updateOrder(String username,UUID orderId, OrderReqDto.UpdateOrder updateOrderDTO) {
+        // 정보 가져오기
+        Order order  = orderDataFinder.findOrder(orderId);
+        User user = orderDataFinder.findUser(username);
+
+        // 권한 체크 ( 주문의 주인인지 )
+        orderPreConditionChecker.authoriseOrderCustomer(order,user);
+        orderPreConditionChecker.validateModifiable(order);
+
+        if (updateOrderDTO.addressId()!=null)
+        {
+            Address orderAddress = orderDataFinder.findAddress(updateOrderDTO.addressId());
+            order.updateAddress(orderAddress);
+        }
+        // 주문 상품 처리
+        order.removeOrderItems(updateOrderDTO.removeOrderItemIds());
+        if (updateOrderDTO.addOrderItems()!=null && !updateOrderDTO.addOrderItems().isEmpty()) {
+            List<UUID> productIds = updateOrderDTO.addOrderItems().stream().map(OrderReqDto.OrderItem::productId).toList();
+            Map<UUID, Product> stockMap = orderDataFinder.getProductMap(productIds);
+            for (OrderReqDto.OrderItem productItem : updateOrderDTO.addOrderItems()) {
+                Product stock = stockMap.get(productItem.productId());
+                // 매장의 상품이 존재하는 지, 재고가 있는지 확인하는 함수
+                orderPreConditionChecker.validateProduct(stock, order.getStore(), productItem);
+                // 주문 아이템 생성
+                OrderItem orderItem = OrderConverter.toOrderItem(stock, productItem.quantity());
+                order.addOrderItem(orderItem);
+            }
+        }
+        // 주문 상품 처리 후 상품 리스트에 상품이 하나도 안 남았다면 오류
+        orderPreConditionChecker.validateQuantity(order);
+
+        if (updateOrderDTO.requestMemo()!=null)
+            order.updateOrderMessage(updateOrderDTO.requestMemo());
+        Order savedOrder = orderRepository.save(order);
+        return OrderConverter.toMutationResponse(savedOrder);
+    }
+
+    @Transactional
+    @Override
+    public Void deleteOrder(String username, UUID orderId) {
+        // 정보 가져오기
+        Order order = orderDataFinder.findOrder(orderId);
+        User user = orderDataFinder.findUser(username);
+
+        // 권한 체크
+        orderPreConditionChecker.authoriseOrderCustomer(order,user);
+        orderPreConditionChecker.validateDeletable(order);
+
+        // 상태별 로직 분기
+        if (order.getStatus() == OrderStatus.PENDING)
+            order.updateStatus(OrderStatus.CANCELED,"주문 취소");
+        else
+            order.updateStatus(OrderStatus.HIDDEN,"주문 목록에서 제거");
+        order.deleteOrder(user.getName());
+        return null;
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/entity/Order.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/entity/Order.java
@@ -125,7 +125,6 @@ public class Order {
         if (orderRequestMessage != null && !orderRequestMessage.isBlank()) {
             this.orderRequestMessage = orderRequestMessage;
         }
-        this.orderRequestMessage = orderRequestMessage;
     }
     public void deleteOrder(String deleteBy) {
         if (this.softDeleteAudit == null) {

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/entity/Order.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/entity/Order.java
@@ -50,7 +50,7 @@ public class Order {
     private OrderStatus status = OrderStatus.PENDING;
 
     @Column(name = "total_price", nullable = false)
-    private Long totalPrice;
+    private Integer totalPrice;
 
     @Column(name = "order_request_message", length = 255)
     private String orderRequestMessage;
@@ -75,29 +75,10 @@ public class Order {
     // 양방향 추가
     public void addOrderItem(OrderItem item) {
         this.orderItems.add(item);
+        this.totalPrice += item.getTotalPrice();
         item.setOrder(this);
     }
-    public static Order createOrder(User user, Address address,Store store) {
-        String addressSnapshot = String.format("[%s / %s] %s %s (메모: %s)",
-                address.getReceiverName(),
-                address.getReceiverPhone(),
-                address.getAddressLine1(),
-                address.getAddressLine2() != null ? address.getAddressLine2() : "",
-                address.getDeliveryMemo() != null ? address.getDeliveryMemo() : "없음"
-        );
-        Order order = Order.builder()
-                .user(user)
-                .address(address)
-                .deliveryAddressSnapshot(addressSnapshot)
-                .store(store)
-                .orderItems(new ArrayList<>()) // 리스트 초기화
-                .totalPrice(0L)
-                .createdAudit(CreateAudit.now(user.getName()))
-                .build();
-        order.addStatusHistory(null,OrderStatus.PENDING,"주문 생성");
-        return order;
-    }
-    private void addStatusHistory(OrderStatus from, OrderStatus to, String reason) {
+    public void addStatusHistory(OrderStatus from, OrderStatus to, String reason) {
         OrderStatusHistory history = OrderStatusHistory.builder()
                 .order(this)
                 .fromStatus(from)
@@ -111,5 +92,45 @@ public class Order {
         OrderStatus fromStatus = this.status;
         this.status = toStatus; // 현재 상태 업데이트
         addStatusHistory(fromStatus, toStatus, reason); // 이력 추가
+    }
+    public void updateAddress(Address address)
+    {
+        this.address = address;
+        this.deliveryAddressSnapshot = String.format("[%s / %s] %s %s (메모: %s)",
+                address.getReceiverName(),
+                address.getReceiverPhone(),
+                address.getAddressLine1(),
+                address.getAddressLine2() != null ? address.getAddressLine2() : "",
+                address.getDeliveryMemo() != null ? address.getDeliveryMemo() : "없음"
+        );
+    }
+    public void removeOrderItems(List<UUID> itemIdsToDelete)
+    {
+        if (itemIdsToDelete == null || itemIdsToDelete.isEmpty()) {
+            return;
+        }
+        List<OrderItem> toRemove = this.orderItems.stream()
+                .filter(item -> itemIdsToDelete.contains(item.getOrderItemId()))
+                .toList();
+
+        for (OrderItem item : toRemove) {
+            if (this.totalPrice != null) {
+                this.totalPrice -= item.getTotalPrice();
+            }
+            this.orderItems.remove(item);
+        }
+    }
+    public void updateOrderMessage(String orderRequestMessage)
+    {
+        if (orderRequestMessage != null && !orderRequestMessage.isBlank()) {
+            this.orderRequestMessage = orderRequestMessage;
+        }
+        this.orderRequestMessage = orderRequestMessage;
+    }
+    public void deleteOrder(String deleteBy) {
+        if (this.softDeleteAudit == null) {
+            this.softDeleteAudit = SoftDeleteAudit.active();
+        }
+        this.softDeleteAudit.softDelete(deleteBy);
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/entity/OrderItem.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/entity/OrderItem.java
@@ -1,7 +1,6 @@
 package com.dfdt.delivery.domain.order.domain.entity;
 
 import com.dfdt.delivery.common.infrastructure.persistence.embedded.SoftDeleteAudit;
-import com.dfdt.delivery.domain.product.domain.entity.Product;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -32,13 +31,13 @@ public class OrderItem {
     private Integer quantity;
 
     @Column(name = "unit_price_snapshot", nullable = false)
-    private Long unitPriceSnapshot;
+    private Integer unitPriceSnapshot;
 
     @Column(name = "product_name_snapshot", length = 120, nullable = false)
     private String productNameSnapshot;
 
     @Column(name = "total_price", nullable = false)
-    private Long totalPrice;
+    private Integer totalPrice;
 
     @Embedded
     private SoftDeleteAudit softDeleteAudit;
@@ -48,15 +47,5 @@ public class OrderItem {
         if (!order.getOrderItems().contains(this)) {
             order.getOrderItems().add(this);
         }
-    }
-    // 스냅샷 찍기
-    public static OrderItem createOrderItem(Product product, Integer quantity) {
-        return OrderItem.builder()
-                .productId(product.getProductId())
-                .productNameSnapshot(product.getName())
-                .unitPriceSnapshot(product.getPrice())
-                .quantity(quantity)
-                .totalPrice(product.getPrice() * quantity)
-                .build();
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/enums/OrderStatus.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/enums/OrderStatus.java
@@ -8,5 +8,5 @@ import lombok.RequiredArgsConstructor;
 public enum OrderStatus {
     PENDING, PAID, ACCEPTED, REJECTED,
     COOKING_DONE, DELIVERING, DELIVERED,
-    COMPLETED, CANCELED
+    COMPLETED, CANCELED, HIDDEN
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderCacheManager.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderCacheManager.java
@@ -1,0 +1,9 @@
+package com.dfdt.delivery.domain.order.domain.repository;
+
+
+import java.time.Duration;
+import java.util.UUID;
+
+public interface OrderCacheManager {
+    void setPaymentTimeout(UUID orderId, Duration timeout);
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderRepository.java
@@ -1,4 +1,12 @@
 package com.dfdt.delivery.domain.order.domain.repository;
 
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+
+import java.util.Optional;
+import java.util.UUID;
+
 public interface OrderRepository {
+    Order save(Order order);
+    Optional<Order> findById(UUID orderId);
+    Optional<Order> findByIdWithLock(UUID orderId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/JpaOrderRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/JpaOrderRepository.java
@@ -2,9 +2,18 @@ package com.dfdt.delivery.domain.order.infrastructure.persistence.repository;
 
 import com.dfdt.delivery.domain.order.domain.entity.Order;
 import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface JpaOrderRepository extends JpaRepository<Order, UUID> , OrderRepository {
+
+    @Override
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select o from Order o where o.orderId = :orderId")
+    Optional<Order> findByIdWithLock(UUID orderId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.dfdt.delivery.domain.order.presentation.controller;
 
 import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
 import com.dfdt.delivery.domain.order.application.service.query.OrderQueryService;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
@@ -8,7 +9,10 @@ import com.dfdt.delivery.domain.order.application.service.command.OrderCommandSe
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
 
 
 @RestController
@@ -18,18 +22,17 @@ public class OrderController implements OrderControllerDocs {
     private final OrderCommandService orderCommandService;
     private final OrderQueryService orderQueryService;
 
-    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
 
     // API-001 주문 생성하기
-    @PostMapping("/{user_id}")
+    @PostMapping()
     public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> createOrder(
-            @PathVariable (value = "user_id") String userId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody  OrderReqDto.Create createDTO)
     {
         return ApiResponseDto.success(
                 201,
                 "주문이 생성되었습니다.",
-                null
+                orderCommandService.createOrder(customUserDetails.getUsername(),createDTO)
         );
     }
     // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
@@ -59,33 +62,31 @@ public class OrderController implements OrderControllerDocs {
                 null
         );
     }
-    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
 
     // API-004 주문 수정하기
-    @PatchMapping("/{order_id}/{user_id}")
+    @PatchMapping("/{order_id}")
     public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrder(
-            @PathVariable (value = "order_id") String orderId,
-            @PathVariable (value = "user_id") String  userId,
+            @PathVariable (value = "order_id") UUID orderId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody OrderReqDto.UpdateOrder updateDTO
     ) {
         return ApiResponseDto.success(
                 200,
                 "주문이 수정되었습니다.",
-                null
+                orderCommandService.updateOrder(customUserDetails.getUsername(),orderId,updateDTO)
         );
     }
-    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
 
     // API-005 주문 삭제하기
-    @DeleteMapping("/{order_id}/{user_id}")
+    @DeleteMapping("/{order_id}")
     public ResponseEntity<ApiResponseDto<Void>> deleteOrder(
-            @PathVariable (value = "order_id") String orderId,
-            @PathVariable (value = "user_id") String  userId
+            @PathVariable (value = "order_id") UUID orderId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         return ApiResponseDto.success(
                 200,
                 "주문이 삭제되었습니다.",
-                null
+                orderCommandService.deleteOrder(customUserDetails.getUsername(),orderId)
         );
     }
     // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
@@ -1,6 +1,7 @@
 package com.dfdt.delivery.domain.order.presentation.controller;
 
 import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,8 +12,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.UUID;
 
 @Tag(name = "Order (주문)", description = "주문 생성 및 상태 관리를 담당합니다.")
 public interface OrderControllerDocs {
@@ -36,7 +40,7 @@ public interface OrderControllerDocs {
             })),
     })
     ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> createOrder(
-            @PathVariable(value = "user_id") String userId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody OrderReqDto.Create createDTO);
 
 
@@ -78,8 +82,8 @@ public interface OrderControllerDocs {
             })),
     })
     ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrder(
-            @PathVariable(value = "order_id") String orderId,
-            @PathVariable(value = "user_id") String userId,
+            @PathVariable(value = "order_id") UUID orderId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody OrderReqDto.UpdateOrder updateDTO
     );
 
@@ -98,8 +102,8 @@ public interface OrderControllerDocs {
             })),
     })
     ResponseEntity<ApiResponseDto<Void>> deleteOrder(
-            @PathVariable(value = "order_id") String orderId,
-            @PathVariable(value = "user_id") String userId);
+            @PathVariable(value = "order_id") UUID orderId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
 
     

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
@@ -14,7 +14,7 @@ public class OrderReqDto {
             @NotNull(message = "주소가 입력되지 않았습니다.")
             UUID addressId,
             @NotEmpty(message = "하나 이상의 상품이 들어있어야 합니다.")
-            List<OrderItem> productItemList,
+            List<OrderItem> orderItems,
             @Length(max = 255,message = "최대 255자 입니다.")
             String requestMemo
     ){}
@@ -24,11 +24,12 @@ public class OrderReqDto {
             @NotNull(message = "상품 수량이 입력되지 않았습니다.")
             Integer quantity,
             @NotNull(message = "상품 가격이 입력되지 않았습니다.")
-            Long userViewedUnitPrice
+            Integer userViewedUnitPrice
     ){}
     public record UpdateOrder(
             UUID addressId,
-            List<OrderItem> orderItems,
+            List<OrderItem> addOrderItems,
+            List<UUID> removeOrderItemIds,
             @Length(max = 255,message = "최대 255자 입니다.")
             String requestMemo
     ){}

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderResDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderResDto.java
@@ -23,7 +23,7 @@ public class OrderResDto {
             UUID orderStoreId,
             String orderStoreName,
             OffsetDateTime orderedAt,
-            Long totalPrice,
+            Integer totalPrice,
             Integer totalQuantity,
             String representativeProductName,
             String orderAddress,
@@ -40,18 +40,18 @@ public class OrderResDto {
 
     @Builder
     public record OrderSummaryCount(
-            long pendingCount,
-            long paidCount,
-            long cookingCount,
-            long doneCount,
-            long canceledCount
+            Integer pendingCount,
+            Integer paidCount,
+            Integer cookingCount,
+            Integer doneCount,
+            Integer canceledCount
     ){}
 
     @Builder
     public record OwnerOrderUnit(
             UUID orderId,
             OffsetDateTime orderTime,
-            Long totalPrice,
+            Integer totalPrice,
             Integer totalQuantity,
             String orderAddress,
             List<ProductSimpleInfo> products
@@ -68,12 +68,12 @@ public class OrderResDto {
             Integer totalQuantity,
             String orderAddress,
             OrderStatus orderStatus,
-            List<OrderItemDetail> orderItemDetails,
+            List<OrderItemResponse> orderItemDetails,
             List<OrderStatusHistoryDetail> orderStatusHistoryDetails
     ){}
 
     @Builder
-    public record OrderItemDetail(
+    public record OrderItemResponse(
             UUID productId,
             String productName,
             Integer quantity,
@@ -102,8 +102,9 @@ public class OrderResDto {
             UUID orderId,
             OrderStatus orderStatus,
             String orderAddress,
-            Long totalPrice,
-            List<OrderItemDetail> items, // 상세 수정 시에만 포함, 그 외엔 null/empty
+            Integer totalPrice,
+            String representativeProductName,
+            String orderRequestMessage,
             OffsetDateTime updatedAt
     ){}
 


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #2 

## 📌 작업 내용
주문 도메인의 핵심 비즈니스 로직인 생성(Create), 수정(Update), 삭제(Delete) 기능을 구현하고, 도메인 무결성 및 동시성 제어를 위한 최적화 작업을 진행했습니다.

## ✅ 주요 변경 사항
- **비즈니스 로직 세분화 및 책임 분리**:
    - `OrderDataFinder`: 유저, 매장, 주소 등 도메인 객체 조회를 전담하여 서비스 코드 가독성 향상
    - `OrderPreConditionChecker`: 재고, 권한, 매장-상품 일치 여부 등 비즈니스 제약 조건 검증 전담
- **동시성 및 데이터 정합성 확보**:
    - **비관적 락(Pessimistic Lock)** 적용: 주문 수정/삭제 시 중복 요청 및 데이터 경합 방지
    - **주소 스냅샷**: 주문 시점의 배송지 정보를 `deliveryAddressSnapshot` 컬럼에 문자열로 보존하여 정합성 확보
- **도메인 정책 수립 및 구현**:
    - **Update**: 권한 검증 및 주문 아이템의 Add/Remove 리스트 분리 처리 (수량 수정 불가 정책 적용)
    - **Delete**: Soft Delete 기반 구현 (결제 전 취소 vs 완료 후 목록 제거 시나리오 분리)
- **인프라 및 컨버터 최적화**:
    - `UserPrincipal` 연동을 통한 인증 객체 처리 로직 반영
    - `OrderConverter` 도입을 통한 엔티티 생성 및 응답 DTO 가공 로직 캡슐화

## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인
- [x] 예외 케이스 확인

### 확인 방법
1. **주문 생성**: 정상 생성(201) 및 재고 부족/가격 변동 등 예외 케이스 5종 검증 완료
2. **주문 수정**: 권한 없는 유저 접근 및 이미 처리된 주문 수정 시도 시 에러 반환 확인
3. **주문 삭제**: Soft Delete 처리 후 DB상 `deleted_at` 필드 반영 및 목록 조회 제외 확인

<details>
<summary><b> 상세 테스트 결과 및 예외 케이스 확인 (클릭)</b></summary>

### 1. 주문 생성
**API Response (201 Created)**
<img width="1138" height="653" alt="스크린샷 2026-03-05 084630" src="https://github.com/user-attachments/assets/1623313d-dfb3-4e85-b305-aa667002a2e4" />

**예외 상황**
|에러코드|상황|확인|
|---|---|---|
|order-4000|주문 수량 오류|✅|
|order-4001|가게 상품 불일치|✅|
|order-4004|상품 가격 변동|✅|
|order-4031|판매 중지 상품|✅|
|store,address,product-404|찾을 수 없음|✅|

---

### 2. 주문 수정
**API Response (200 OK)**
<img width="1178" height="654" alt="스크린샷 2026-03-05 105852" src="https://github.com/user-attachments/assets/2b682bd6-6fe0-46c6-b304-a3cbb05d574b" />

**예외 상황**
|에러코드|상황|확인|
|---|---|---|
|order-4000|주문 수량 오류|✅|
|order-4001|가게 상품 불일치|✅|
|order-4002|이미 처리된 주문|✅|
|order-4004|상품 가격 변동|✅|
|order-4010|접근 권한 없음|✅|
|order-4031|판매 중지 상품|✅|
|address,product,order-404|찾을 수 없음|✅|

---

### 3. 주문 삭제
**API Response (200 OK)**
<img width="1138" height="431" alt="스크린샷 2026-03-05 105904" src="https://github.com/user-attachments/assets/e8947567-d869-474d-bf2e-4ed7ee8d78b7" />

**예외 상황**
|에러코드|상황|확인|
|---|---|---|
|order-4002|이미 처리된 주문|✅|
|order-4010|접근 권한 없음|✅|
|address,product,order-404|찾을 수 없음|✅|

</details>

## ⚠️ 영향 범위
- [x] API 스펙 변경 (CUD 엔드포인트 실로직 연결)
- [x] DB 스키마 변경 (배송지 스냅샷 컬럼 및 Soft Delete 필드 활용)
- [x] 응답값/에러코드 변경 (OrderErrorDocs 기반 커스텀 에러 적용)
- [ ] 환경설정 변경
- [x] 문서(Swagger/README) 수정

## 👀 리뷰 포인트
- **동시성 제어**: 수정/삭제 시 적용된 락의 범위가 적절한지, 성능상 병목 가능성은 없는지 검토 부탁드립니다.
- **도메인 정책**: 주문 수정 시 '수량 변경 불가' 및 '아이템 추가/삭제만 허용'하는 정책이 비즈니스 요구사항에 부합하는지 확인해 주세요.
- **스냅샷 전략**: 배송지 정보를 단순 문자열 스냅샷으로 보관하는 방식에 대해 의견 주시면 감사하겠습니다.
- ** 폴더 구조** : 이 구현체가 헥사고날 클린 아키텍처를 준수하는 지 봐주세요!