### PR TITLE
[Feat] Auth 비즈니스 로직 및 중복 로그인 방지 기능 구현

### DIFF
--- a/src/main/java/com/dfdt/delivery/common/config/SecurityConfig.java
+++ b/src/main/java/com/dfdt/delivery/common/config/SecurityConfig.java
@@ -19,6 +19,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+/**
+ * 애플리케이션의 전반적인 보안 설정을 담당하는 클래스.
+ * JWT 기반의 Stateless 인증 방식을 구성하며, 필터 체인 및 경로별 접근 권한을 정의.
+ */
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
@@ -30,26 +34,45 @@ public class SecurityConfig {
     private final RedisService redisService;
     private final ObjectMapper objectMapper;
 
+    /**
+     * 비밀번호 암호화에 사용할 PasswordEncoder를 빈으로 등록.
+     * 보안 표준인 BCrypt 알고리즘을 사용.
+     */
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
+    /**
+     * JWT 인증을 수행하는 커스텀 필터를 빈으로 등록.
+     */
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
         return new JwtAuthenticationFilter(jwtProvider, userDetailsService, redisService);
     }
 
+    /**
+     * JWT 인증 과정 중 발생하는 예외를 처리하는 필터를 빈으로 등록.
+     */
     @Bean
     public JwtExceptionFilter jwtExceptionFilter() {
         return new JwtExceptionFilter(objectMapper);
     }
 
+    /**
+     * HTTP 보안 필터 체인을 구성.
+     * CSRF 비활성화, 세션 정책 설정, 경로별 권한 설정, 커스텀 필터 등록 등을 수행.
+     */
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                // CSRF 설정 비활성화 (Stateless한 JWT 방식에서는 불필요)
                 .csrf(AbstractHttpConfigurer::disable)
+                
+                // 세션 관리 정책 설정: 세션을 사용하지 않음 (STATELESS)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                
+                // HTTP 요청별 접근 제어 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/v1/auth/**",
@@ -64,10 +87,11 @@ public class SecurityConfig {
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
+                
+                // 커스텀 필터 배치 순서 결정
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(jwtExceptionFilter(), JwtAuthenticationFilter.class);
 
         return http.build();
     }
 }
-

--- a/src/main/java/com/dfdt/delivery/common/config/SecurityConfig.java
+++ b/src/main/java/com/dfdt/delivery/common/config/SecurityConfig.java
@@ -53,6 +53,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/v1/auth/**",
+                                "/api/v1/swagger",
+                                "/api/v1/swagger-ui/**",
+                                "/api/v1/v3/api-docs/**",
+                                "/api/v1/api-docs/**",
                                 "/swagger",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/src/main/java/com/dfdt/delivery/domain/auth/application/AuthService.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/application/AuthService.java
@@ -91,8 +91,12 @@ public class AuthService {
         String newAccessToken = jwtProvider.createAccessToken(username, role);
         String newRefreshToken = jwtProvider.createRefreshToken(username, role);
 
-        // Redis 갱신
-        redisService.setData(REFRESH_TOKEN_PREFIX + username, jwtProvider.resolveToken(newRefreshToken), 7 * 24 * 60 * 60 * 1000L);
+        String pureNewAccessToken = jwtProvider.resolveToken(newAccessToken);
+        String pureNewRefreshToken = jwtProvider.resolveToken(newRefreshToken);
+
+        // Redis 갱신 (RT와 AT 모두 갱신)
+        redisService.setData(ACTIVE_TOKEN_PREFIX + username, pureNewAccessToken, 60 * 60 * 1000L);
+        redisService.setData(REFRESH_TOKEN_PREFIX + username, pureNewRefreshToken, 7 * 24 * 60 * 60 * 1000L);
 
         return TokenResponseDto.of(newAccessToken, newRefreshToken);
     }

--- a/src/main/java/com/dfdt/delivery/domain/auth/application/AuthService.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/application/AuthService.java
@@ -15,6 +15,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 인증 관련 핵심 비즈니스 로직을 담당하는 서비스 클래스.
+ * 로그인, 로그아웃, 토큰 재발급 및 세션 관리(중복 로그인 방지)를 수행.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -29,74 +33,97 @@ public class AuthService {
     private static final String BLACKLIST_PREFIX = "blacklist:";
     private static final String ACTIVE_TOKEN_PREFIX = "active_token:";
 
+    /**
+     * 사용자 로그인을 처리.
+     * @param requestDto 아이디와 비밀번호 정보를 담은 DTO
+     * @return Access Token과 Refresh Token 세트
+     */
     @Transactional
     public TokenResponseDto login(LoginRequestDto requestDto) {
+        // 1. 사용자 존재 여부 확인
         User user = userRepository.findByUsername(requestDto.getUsername())
                 .orElseThrow(() -> new BusinessException(AuthErrorCode.LOGIN_FAILED));
 
+        // 2. 비밀번호 일치 여부 확인 (BCrypt 대조)
         if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
             throw new BusinessException(AuthErrorCode.LOGIN_FAILED);
         }
 
-        // 로그인 기록 갱신
+        // 3. 로그인 성공 기록 (Last Login At 갱신)
         user.recordLogin();
 
+        // 4. 새로운 토큰 쌍(AT, RT) 생성
         String accessToken = jwtProvider.createAccessToken(user.getUsername(), user.getRole());
         String refreshToken = jwtProvider.createRefreshToken(user.getUsername(), user.getRole());
 
+        // 5. Redis 저장용 순수 토큰 값 추출 (Bearer 접두사 제거)
         String pureAccessToken = jwtProvider.resolveToken(accessToken);
         String pureRefreshToken = jwtProvider.resolveToken(refreshToken);
 
-        // Redis에 Refresh Token 저장 (7일)
+        // 6. Redis 데이터 갱신
+        // - Refresh Token: 재발급용 (7일 유지)
         redisService.setData(REFRESH_TOKEN_PREFIX + user.getUsername(), pureRefreshToken, 7 * 24 * 60 * 60 * 1000L);
-        
-        // Redis에 현재 활성화된 Access Token 저장 (중복 로그인 방지용)
+        // - Active Token: 중복 로그인 방지용 (1시간 유지)
         redisService.setData(ACTIVE_TOKEN_PREFIX + user.getUsername(), pureAccessToken, 60 * 60 * 1000L);
 
         return TokenResponseDto.of(accessToken, refreshToken);
     }
 
+    /**
+     * 사용자 로그아웃을 처리.
+     * @param bearerToken 현재 사용 중인 Access Token
+     * @param username 로그아웃할 사용자의 아이디
+     */
     @Transactional
     public void logout(String bearerToken, String username) {
         String accessToken = jwtProvider.resolveToken(bearerToken);
         
-        // 1. Redis에서 Refresh Token 삭제
+        // 1. Redis에서 해당 유저의 Refresh Token 삭제 (재발급 불가 처리)
         redisService.deleteData(REFRESH_TOKEN_PREFIX + username);
+        // 2. Redis에서 해당 유저의 활성 토큰 정보 삭제
+        redisService.deleteData(ACTIVE_TOKEN_PREFIX + username);
 
-        // 2. Access Token 블랙리스트 등록 (남은 유효시간 동안)
+        // 3. Access Token 블랙리스트 등록 (남은 유효시간 동안 해당 토큰 사용 차단)
         long expiration = jwtProvider.getExpiration(accessToken);
         redisService.setData(BLACKLIST_PREFIX + accessToken, "logout", expiration);
     }
 
+    /**
+     * Refresh Token을 사용하여 새로운 Access/Refresh 토큰을 재발급.
+     * @param bearerRefreshToken 사용자가 제출한 Refresh Token
+     * @return 새로운 Access Token과 Refresh Token 세트
+     */
     @Transactional
     public TokenResponseDto reissue(String bearerRefreshToken) {
         String refreshToken = jwtProvider.resolveToken(bearerRefreshToken);
 
+        // 1. Refresh Token 자체의 유효성(만료, 서명 등) 검증
         if (!jwtProvider.validateToken(refreshToken)) {
             throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
+        // 2. 토큰에서 유저 정보 추출
         Claims claims = jwtProvider.getUserInfoFromToken(refreshToken);
         String username = claims.getSubject();
         String roleStr = claims.get("role", String.class);
         UserRole role = UserRole.valueOf(roleStr);
 
-        // Redis에 저장된 토큰과 일치하는지 확인
+        // 3. Redis에 저장된 토큰과 사용자가 제출한 토큰이 일치하는지 확인 (탈취 방지)
         String savedToken = (String) redisService.getData(REFRESH_TOKEN_PREFIX + username);
         if (savedToken == null || !savedToken.equals(refreshToken)) {
             throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
         }
 
-        // 새로운 토큰 발급
+        // 4. 새로운 토큰 쌍 발급
         String newAccessToken = jwtProvider.createAccessToken(username, role);
         String newRefreshToken = jwtProvider.createRefreshToken(username, role);
 
         String pureNewAccessToken = jwtProvider.resolveToken(newAccessToken);
         String pureNewRefreshToken = jwtProvider.resolveToken(newRefreshToken);
 
-        // Redis 갱신 (RT와 AT 모두 갱신)
-        redisService.setData(ACTIVE_TOKEN_PREFIX + username, pureNewAccessToken, 60 * 60 * 1000L);
+        // 5. Redis 데이터 최신화 (새로운 RT와 AT 정보 기록)
         redisService.setData(REFRESH_TOKEN_PREFIX + username, pureNewRefreshToken, 7 * 24 * 60 * 60 * 1000L);
+        redisService.setData(ACTIVE_TOKEN_PREFIX + username, pureNewAccessToken, 60 * 60 * 1000L);
 
         return TokenResponseDto.of(newAccessToken, newRefreshToken);
     }

--- a/src/main/java/com/dfdt/delivery/domain/auth/application/AuthService.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/application/AuthService.java
@@ -1,0 +1,99 @@
+package com.dfdt.delivery.domain.auth.application;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.common.util.RedisService;
+import com.dfdt.delivery.domain.auth.domain.exception.error.enums.AuthErrorCode;
+import com.dfdt.delivery.domain.auth.infrastructure.jwt.JwtProvider;
+import com.dfdt.delivery.domain.auth.presentation.dto.LoginRequestDto;
+import com.dfdt.delivery.domain.auth.presentation.dto.TokenResponseDto;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import com.dfdt.delivery.domain.user.domain.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtProvider jwtProvider;
+    private final RedisService redisService;
+
+    private static final String REFRESH_TOKEN_PREFIX = "refresh:";
+    private static final String BLACKLIST_PREFIX = "blacklist:";
+    private static final String ACTIVE_TOKEN_PREFIX = "active_token:";
+
+    @Transactional
+    public TokenResponseDto login(LoginRequestDto requestDto) {
+        User user = userRepository.findByUsername(requestDto.getUsername())
+                .orElseThrow(() -> new BusinessException(AuthErrorCode.LOGIN_FAILED));
+
+        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+            throw new BusinessException(AuthErrorCode.LOGIN_FAILED);
+        }
+
+        // 로그인 기록 갱신
+        user.recordLogin();
+
+        String accessToken = jwtProvider.createAccessToken(user.getUsername(), user.getRole());
+        String refreshToken = jwtProvider.createRefreshToken(user.getUsername(), user.getRole());
+
+        String pureAccessToken = jwtProvider.resolveToken(accessToken);
+        String pureRefreshToken = jwtProvider.resolveToken(refreshToken);
+
+        // Redis에 Refresh Token 저장 (7일)
+        redisService.setData(REFRESH_TOKEN_PREFIX + user.getUsername(), pureRefreshToken, 7 * 24 * 60 * 60 * 1000L);
+        
+        // Redis에 현재 활성화된 Access Token 저장 (중복 로그인 방지용)
+        redisService.setData(ACTIVE_TOKEN_PREFIX + user.getUsername(), pureAccessToken, 60 * 60 * 1000L);
+
+        return TokenResponseDto.of(accessToken, refreshToken);
+    }
+
+    @Transactional
+    public void logout(String bearerToken, String username) {
+        String accessToken = jwtProvider.resolveToken(bearerToken);
+        
+        // 1. Redis에서 Refresh Token 삭제
+        redisService.deleteData(REFRESH_TOKEN_PREFIX + username);
+
+        // 2. Access Token 블랙리스트 등록 (남은 유효시간 동안)
+        long expiration = jwtProvider.getExpiration(accessToken);
+        redisService.setData(BLACKLIST_PREFIX + accessToken, "logout", expiration);
+    }
+
+    @Transactional
+    public TokenResponseDto reissue(String bearerRefreshToken) {
+        String refreshToken = jwtProvider.resolveToken(bearerRefreshToken);
+
+        if (!jwtProvider.validateToken(refreshToken)) {
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        Claims claims = jwtProvider.getUserInfoFromToken(refreshToken);
+        String username = claims.getSubject();
+        String roleStr = claims.get("role", String.class);
+        UserRole role = UserRole.valueOf(roleStr);
+
+        // Redis에 저장된 토큰과 일치하는지 확인
+        String savedToken = (String) redisService.getData(REFRESH_TOKEN_PREFIX + username);
+        if (savedToken == null || !savedToken.equals(refreshToken)) {
+            throw new BusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+
+        // 새로운 토큰 발급
+        String newAccessToken = jwtProvider.createAccessToken(username, role);
+        String newRefreshToken = jwtProvider.createRefreshToken(username, role);
+
+        // Redis 갱신
+        redisService.setData(REFRESH_TOKEN_PREFIX + username, jwtProvider.resolveToken(newRefreshToken), 7 * 24 * 60 * 60 * 1000L);
+
+        return TokenResponseDto.of(newAccessToken, newRefreshToken);
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/auth/domain/exception/error/enums/AuthErrorCode.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/domain/exception/error/enums/AuthErrorCode.java
@@ -18,6 +18,7 @@ public enum AuthErrorCode implements ErrorCode {
     EXPIRED_ACCESS_TOKEN(401, "AUTH-4013", "만료된 Access Token입니다."),
     INVALID_ACCESS_TOKEN(401, "AUTH-4014", "유효하지 않거나 손상된 Access Token입니다."),
     INVALID_REFRESH_TOKEN(401, "AUTH-4015", "유효하지 않거나 만료된 Refresh Token입니다."),
+    DUPLICATE_LOGIN(401, "AUTH-4016", "중복 로그인하여 현재 세션이 만료되었습니다."),
 
     // 403 FORBIDDEN
     FORBIDDEN(403, "AUTH-4030", "접근 권한이 없습니다."),

--- a/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -20,6 +20,10 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+/**
+ * 모든 요청에서 JWT 토큰을 추출하고 유효성을 검증하여 Spring Security 인증 정보를 설정하는 필터.
+ * 중복 로그인 방지 로직과 블랙리스트 확인 로직을 포함.
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -32,31 +36,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
+        // 요청 헤더에서 JWT 토큰을 추출.
         String token = jwtProvider.resolveToken(request.getHeader(JwtProvider.AUTHORIZATION_HEADER));
 
         if (StringUtils.hasText(token)) {
-            // 1. 블랙리스트 확인 (로그아웃 된 토큰인지)
+            // 블랙리스트 확인: 사용자가 로그아웃한 토큰인지 Redis에서 조회.
             if (redisService.hasKey("blacklist:" + token)) {
                 log.warn("Blacklisted token accessed: {}", token);
                 filterChain.doFilter(request, response);
                 return;
             }
 
-            // 2. JWT 유효성 및 만료 확인
+            // JWT 유효성 및 만료 기간 확인: 기술적으로 유효한 토큰인지 검증.
             if (!jwtProvider.validateToken(token)) {
                 log.error("Token validation failed");
                 filterChain.doFilter(request, response);
                 return;
             }
 
+            // 사용자 정보 추출: 토큰 내부의 Claims에서 username(Subject)을 가져옵니다.
             Claims info = jwtProvider.getUserInfoFromToken(token);
             String username = info.getSubject();
 
-            // 3. 중복 로그인 확인 (Redis에 저장된 최신 활성 토큰과 일치하는지)
+            // 중복 로그인 확인 (Active Token 체크)
             String activeToken = (String) redisService.getData("active_token:" + username);
             if (activeToken != null && !activeToken.equals(token)) {
                 log.warn("Duplicate login detected for user: {}. Current token is outdated.", username);
-                throw new JwtException(AuthErrorCode.DUPLICATE_LOGIN.name());
+                throw new JwtException(AuthErrorCode.TOKEN_VERSION_MISMATCH.name());
             }
 
             setAuthentication(username);
@@ -65,6 +71,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
+    /**
+     * Spring Security의 ContextHolder에 인증 객체를 담는다.
+     * 비즈니스 로직(Controller 등)에서 @AuthenticationPrincipal을 사용.
+     * @param username 인증된 사용자의 아이디
+     */
     public void setAuthentication(String username) {
         UserDetails userDetails = userDetailsService.loadUserByUsername(username);
         Authentication authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());

--- a/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -1,8 +1,10 @@
 package com.dfdt.delivery.domain.auth.infrastructure.jwt;
 
 import com.dfdt.delivery.common.util.RedisService;
+import com.dfdt.delivery.domain.auth.domain.exception.error.enums.AuthErrorCode;
 import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetailsService;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -29,16 +31,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
+
         String token = jwtProvider.resolveToken(request.getHeader(JwtProvider.AUTHORIZATION_HEADER));
 
         if (StringUtils.hasText(token)) {
-            // 블랙리스트 확인 (로그아웃 된 토큰인지)
+            // 1. 블랙리스트 확인 (로그아웃 된 토큰인지)
             if (redisService.hasKey("blacklist:" + token)) {
                 log.warn("Blacklisted token accessed: {}", token);
                 filterChain.doFilter(request, response);
                 return;
             }
 
+            // 2. JWT 유효성 및 만료 확인
             if (!jwtProvider.validateToken(token)) {
                 log.error("Token validation failed");
                 filterChain.doFilter(request, response);
@@ -46,7 +50,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             Claims info = jwtProvider.getUserInfoFromToken(token);
-            setAuthentication(info.getSubject());
+            String username = info.getSubject();
+
+            // 3. 중복 로그인 확인 (Redis에 저장된 최신 활성 토큰과 일치하는지)
+            String activeToken = (String) redisService.getData("active_token:" + username);
+            if (activeToken != null && !activeToken.equals(token)) {
+                log.warn("Duplicate login detected for user: {}. Current token is outdated.", username);
+                throw new JwtException(AuthErrorCode.DUPLICATE_LOGIN.name());
+            }
+
+            setAuthentication(username);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/jwt/JwtExceptionFilter.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/jwt/JwtExceptionFilter.java
@@ -2,8 +2,8 @@ package com.dfdt.delivery.domain.auth.infrastructure.jwt;
 
 import com.dfdt.delivery.common.exception.ErrorCode;
 import com.dfdt.delivery.common.response.ErrorResponseDto;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.dfdt.delivery.domain.auth.domain.exception.error.enums.AuthErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.JwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -16,6 +16,10 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+/**
+ * JWT 관련 인증 예외를 가로채서 공통 에러 응답(JSON)을 반환하는 필터.
+ * JwtAuthenticationFilter 앞에서 작동하여 해당 필터에서 던지는 JwtException을 처리.
+ */
 @Slf4j
 @RequiredArgsConstructor
 public class JwtExceptionFilter extends OncePerRequestFilter {
@@ -41,6 +45,11 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
         }
     }
 
+    /**
+     * HttpServletResponse에 직접 JSON 에러 응답을 작성.
+     * @param response HTTP 응답 객체
+     * @param errorCode 발생한 에러 코드 정보
+     */
     private void setErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
         response.setStatus(errorCode.getStatus());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/jwt/JwtProvider.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/jwt/JwtProvider.java
@@ -30,21 +30,42 @@ public class JwtProvider {
     private final long ACCESS_TOKEN_TIME = 60 * 60 * 1000L;
     private final long REFRESH_TOKEN_TIME = 7 * 24 * 60 * 60 * 1000L;
 
+    /**
+     * Secret Key를 설정합니다.
+     */
     @PostConstruct
     public void init() {
         byte[] bytes = Decoders.BASE64.decode(secretKey);
         key = Keys.hmacShaKeyFor(bytes);
     }
 
-    // 토큰 생성
+    /**
+     * 사용자 정보를 Access Token을 생성.
+     * @param username 사용자 아이디
+     * @param role 사용자 권한
+     * @return 생성된 Access Token (Bearer 접두사 포함)
+     */
     public String createAccessToken(String username, UserRole role) {
         return createToken(username, role, ACCESS_TOKEN_TIME);
     }
 
+    /**
+     * 사용자 정보를 Refresh Token을 생성.
+     * @param username 사용자 아이디
+     * @param role 사용자 권한
+     * @return 생성된 Refresh Token (Bearer 접두사 포함)
+     */
     public String createRefreshToken(String username, UserRole role) {
         return createToken(username, role, REFRESH_TOKEN_TIME);
     }
 
+    /**
+     * 공통 토큰 생성 로직.
+     * @param username 사용자 아이디
+     * @param role 사용자 권한
+     * @param expireTime 만료 시간 (밀리초)
+     * @return 생성된 JWT 토큰 문자열
+     */
     private String createToken(String username, UserRole role, long expireTime) {
         Date date = new Date();
         return BEARER_PREFIX +
@@ -57,7 +78,12 @@ public class JwtProvider {
                         .compact();
     }
 
-    // 토큰 검증 (예외를 직접 던짐)
+    /**
+     * 토큰의 유효성 및 만료 여부를 검증.
+     * @param token 검증할 순수 토큰 문자열
+     * @return 유효할 경우 true 반환
+     * @throws JwtException 유효하지 않거나 만료된 토큰일 경우 예외 발생
+     */
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
@@ -77,11 +103,20 @@ public class JwtProvider {
         }
     }
 
-    // 토큰에서 정보 추출
+    /**
+     * 토큰 내부의 사용자 정보(Claims)를 추출.
+     * @param token 추출할 순수 토큰 문자열
+     * @return 토큰에 포함된 Claims 정보
+     */
     public Claims getUserInfoFromToken(String token) {
         return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
     }
 
+    /**
+     * Header에서 Bearer 접두사를 제거하고 순수한 토큰 값만 추출.
+     * @param bearerToken "Bearer "로 시작하는 토큰 문자열
+     * @return 접두사가 제거된 순수 토큰 (Bearer로 시작하지 않으면 null 반환)
+     */
     public String resolveToken(String bearerToken) {
         if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(7);
@@ -89,6 +124,11 @@ public class JwtProvider {
         return null;
     }
 
+    /**
+     * 토큰의 남은 유효 시간을 계산.
+     * @param token 계산할 순수 토큰 문자열
+     * @return 남은 시간 (밀리초)
+     */
     public long getExpiration(String token) {
         return getUserInfoFromToken(token).getExpiration().getTime() - new Date().getTime();
     }

--- a/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/security/CustomUserDetails.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/security/CustomUserDetails.java
@@ -10,6 +10,10 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.Collections;
 
+/**
+ * Spring Security에서 인증된 사용자 정보를 보관하기 위한 구현체.
+ * 시스템의 User 엔티티 정보를 Spring Security의 권한 규격(UserDetails)으로 변환하는 역할.
+ */
 @Getter
 public class CustomUserDetails implements UserDetails {
     private final String username;
@@ -24,6 +28,10 @@ public class CustomUserDetails implements UserDetails {
         this.role = user.getRole();
     }
 
+    /**
+     * 사용자가 가진 권한 목록을 반환합니다.
+     * UserRole Enum 값을 "ROLE_CUSTOMER" 등과 같이 Spring Security 권한 규격 문자열로 변환.
+     */
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singletonList(new SimpleGrantedAuthority("ROLE_" + role.name()));
@@ -39,21 +47,33 @@ public class CustomUserDetails implements UserDetails {
         return username;
     }
 
+    /**
+     * 계정 만료 여부를 반환. (true: 만료 안됨)
+     */
     @Override
     public boolean isAccountNonExpired() {
         return true;
     }
 
+    /**
+     * 계정 잠김 여부를 반환. (true: 잠기지 않음)
+     */
     @Override
     public boolean isAccountNonLocked() {
         return true;
     }
 
+    /**
+     * 자격 증명(비밀번호) 만료 여부를 반환. (true: 만료 안됨)
+     */
     @Override
     public boolean isCredentialsNonExpired() {
         return true;
     }
 
+    /**
+     * 계정 활성화 여부를 반환. (true: 활성)
+     */
     @Override
     public boolean isEnabled() {
         return true;

--- a/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/security/CustomUserDetailsService.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/infrastructure/security/CustomUserDetailsService.java
@@ -9,6 +9,10 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Spring Security에서 사용자 정보를 조회하기 위해 사용하는 서비스 클래스.
+ * DB의 유저 정보를 조회하여 Security 전용 객체인 CustomUserDetails로 가공하여 반환.
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -16,10 +20,17 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     private final UserRepository userRepository;
 
+    /**
+     * 사용자 아이디(username)를 통해 DB에서 유저 정보를 조회.
+     * @param username 조회할 사용자 아이디
+     * @return 인증에 필요한 사용자 상세 객체 (CustomUserDetails)
+     * @throws UsernameNotFoundException 해당 사용자가 없을 경우 발생
+     */
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found: " + username));
+
         return new CustomUserDetails(user);
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/presentation/AuthController.java
@@ -12,19 +12,33 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * 사용자 인증(로그인, 로그아웃, 토큰 재발급)을 위한 API 컨트롤러.
+ */
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
 public class AuthController {
 
     private final AuthService authService;
 
+    /**
+     * 로그인을 수행하고 인증 토큰을 발급.
+     * @param requestDto 아이디, 비밀번호
+     * @return AccessToken, RefreshToken 세트
+     */
     @PostMapping("/login")
     public ResponseEntity<ApiResponseDto<TokenResponseDto>> login(@RequestBody @Valid LoginRequestDto requestDto) {
         TokenResponseDto response = authService.login(requestDto);
         return ApiResponseDto.success(200, "로그인 성공", response);
     }
 
+    /**
+     * 로그아웃을 처리하고 토큰을 무효화.
+     * @param bearerToken 현재 사용 중인 Access Token (Header)
+     * @param userDetails 인증된 사용자 상세 정보
+     * @return 로그아웃 성공 메시지
+     */
     @PostMapping("/logout")
     public ResponseEntity<ApiResponseDto<Void>> logout(
             @RequestHeader(JwtProvider.AUTHORIZATION_HEADER) String bearerToken,
@@ -33,6 +47,11 @@ public class AuthController {
         return ApiResponseDto.success(200, "로그아웃 성공", null);
     }
 
+    /**
+     * 만료된 Access Token을 Refresh Token을 통해 재발급.
+     * @param bearerRefreshToken 현재 사용 중인 Refresh Token (Header)
+     * @return 새로운 AccessToken, RefreshToken 세트
+     */
     @PostMapping("/reissue")
     public ResponseEntity<ApiResponseDto<TokenResponseDto>> reissue(
             @RequestHeader(JwtProvider.AUTHORIZATION_HEADER) String bearerRefreshToken) {

--- a/src/main/java/com/dfdt/delivery/domain/auth/presentation/AuthController.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/presentation/AuthController.java
@@ -1,0 +1,42 @@
+package com.dfdt.delivery.domain.auth.presentation;
+
+import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.auth.application.AuthService;
+import com.dfdt.delivery.domain.auth.infrastructure.jwt.JwtProvider;
+import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
+import com.dfdt.delivery.domain.auth.presentation.dto.LoginRequestDto;
+import com.dfdt.delivery.domain.auth.presentation.dto.TokenResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponseDto<TokenResponseDto>> login(@RequestBody @Valid LoginRequestDto requestDto) {
+        TokenResponseDto response = authService.login(requestDto);
+        return ApiResponseDto.success(200, "로그인 성공", response);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponseDto<Void>> logout(
+            @RequestHeader(JwtProvider.AUTHORIZATION_HEADER) String bearerToken,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        authService.logout(bearerToken, userDetails.getUsername());
+        return ApiResponseDto.success(200, "로그아웃 성공", null);
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponseDto<TokenResponseDto>> reissue(
+            @RequestHeader(JwtProvider.AUTHORIZATION_HEADER) String bearerRefreshToken) {
+        TokenResponseDto response = authService.reissue(bearerRefreshToken);
+        return ApiResponseDto.success(200, "토큰 재발급 성공", response);
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/auth/presentation/dto/LoginRequestDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/presentation/dto/LoginRequestDto.java
@@ -1,0 +1,18 @@
+package com.dfdt.delivery.domain.auth.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class LoginRequestDto {
+    @NotBlank(message = "아이디를 입력해주세요.")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/dfdt/delivery/domain/auth/presentation/dto/TokenResponseDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/auth/presentation/dto/TokenResponseDto.java
@@ -1,0 +1,19 @@
+package com.dfdt.delivery.domain.auth.presentation.dto;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
+public class TokenResponseDto {
+    private String accessToken;
+    private String refreshToken;
+
+    public static TokenResponseDto of(String accessToken, String refreshToken) {
+        return TokenResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/user/domain/entity/User.java
+++ b/src/main/java/com/dfdt/delivery/domain/user/domain/entity/User.java
@@ -56,6 +56,9 @@ public class User {
         this.name = name;
         this.password = password;
         this.role = role;
+        this.createAudit = CreateAudit.now("system");
+        this.updateAudit = UpdateAudit.empty();
+        this.softDeleteAudit = SoftDeleteAudit.active();
     }
 
     // 로그인 성공 시 호출

--- a/src/test/java/com/dfdt/delivery/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/auth/application/AuthServiceTest.java
@@ -1,0 +1,149 @@
+package com.dfdt.delivery.domain.auth.application;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.common.util.RedisService;
+import com.dfdt.delivery.domain.auth.infrastructure.jwt.JwtProvider;
+import com.dfdt.delivery.domain.auth.presentation.dto.LoginRequestDto;
+import com.dfdt.delivery.domain.auth.presentation.dto.TokenResponseDto;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import com.dfdt.delivery.domain.user.domain.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private RedisService redisService;
+
+    @Test
+    @DisplayName("로그인 성공 테스트 - 활성 토큰 저장 포함")
+    void loginSuccessTest() {
+        // given
+        String username = "testuser";
+        String password = "password";
+        LoginRequestDto requestDto = new LoginRequestDto(username, password);
+        User user = User.builder()
+                .username(username)
+                .password("encodedPassword")
+                .role(UserRole.CUSTOMER)
+                .build();
+
+        given(userRepository.findByUsername(username)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(password, user.getPassword())).willReturn(true);
+        
+        given(jwtProvider.createAccessToken(anyString(), any())).willReturn("Bearer accessToken");
+        given(jwtProvider.createRefreshToken(anyString(), any())).willReturn("Bearer refreshToken");
+        
+        // resolveToken이 두 번 호출됨 (Access, Refresh 용)
+        given(jwtProvider.resolveToken(contains("accessToken"))).willReturn("accessToken");
+        given(jwtProvider.resolveToken(contains("refreshToken"))).willReturn("refreshToken");
+
+        // when
+        TokenResponseDto result = authService.login(requestDto);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo("Bearer accessToken");
+        assertThat(result.getRefreshToken()).isEqualTo("Bearer refreshToken");
+        
+        // Redis 저장 확인
+        verify(redisService).setData(eq("refresh:" + username), eq("refreshToken"), anyLong());
+        verify(redisService).setData(eq("active_token:" + username), eq("accessToken"), anyLong());
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 비밀번호 불일치")
+    void loginFailTest() {
+        // given
+        String username = "testuser";
+        LoginRequestDto requestDto = new LoginRequestDto(username, "wrongPassword");
+        User user = User.builder()
+                .username(username)
+                .password("encodedPassword")
+                .build();
+
+        given(userRepository.findByUsername(username)).willReturn(Optional.of(user));
+        given(passwordEncoder.matches(anyString(), anyString())).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> authService.login(requestDto))
+                .isInstanceOf(BusinessException.class);
+    }
+
+    @Test
+    @DisplayName("로그아웃 테스트")
+    void logoutTest() {
+        // given
+        String bearerToken = "Bearer accessToken";
+        String username = "testuser";
+        given(jwtProvider.resolveToken(bearerToken)).willReturn("accessToken");
+        given(jwtProvider.getExpiration("accessToken")).willReturn(1000L);
+
+        // when
+        authService.logout(bearerToken, username);
+
+        // then
+        verify(redisService).deleteData("refresh:" + username);
+        verify(redisService).setData(eq("blacklist:accessToken"), eq("logout"), eq(1000L));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 테스트")
+    void reissueTest() {
+        // given
+        String bearerRefreshToken = "Bearer oldRefreshToken";
+        String refreshToken = "oldRefreshToken";
+        String username = "testuser";
+        UserRole role = UserRole.CUSTOMER;
+
+        given(jwtProvider.resolveToken(bearerRefreshToken)).willReturn(refreshToken);
+        given(jwtProvider.validateToken(refreshToken)).willReturn(true);
+        
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put("role", role.name());
+
+        given(jwtProvider.getUserInfoFromToken(refreshToken)).willReturn(claims);
+        given(redisService.getData("refresh:" + username)).willReturn(refreshToken);
+        
+        given(jwtProvider.createAccessToken(username, role)).willReturn("Bearer newAccessToken");
+        given(jwtProvider.createRefreshToken(username, role)).willReturn("Bearer newRefreshToken");
+        given(jwtProvider.resolveToken(contains("newRefreshToken"))).willReturn("newRefreshToken");
+
+        // when
+        TokenResponseDto result = authService.reissue(bearerRefreshToken);
+
+        // then
+        assertThat(result.getAccessToken()).isEqualTo("Bearer newAccessToken");
+        assertThat(result.getRefreshToken()).isEqualTo("Bearer newRefreshToken");
+        verify(redisService).setData(eq("refresh:" + username), eq("newRefreshToken"), anyLong());
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #9 

## 📌 작업 내용
Auth 도메인의 핵심 비즈니스 API(로그인, 로그아웃, 토큰 재발급)를 구현하고, 보안성을강화하기 위한 단일 세션 정책(중복 로그인 방지)을 적용했습니다. 

## ✅ 주요 변경 사항
   - Auth 비즈니스 API 구현:
       - POST /api/v1/auth/login: 사용자 인증 및 Access/Refresh 토큰 발급.
       - POST /api/v1/auth/logout: Refresh Token 삭제 및 Access Token 블랙리스트 등록.
       - POST /api/v1/auth/reissue: Refresh Token을 통한 토큰 세트 재발급.
   - 중복 로그인 방지 로직 적용:
       - Redis에 active_token:{username}을 저장하여 마지막으로 로그인한 기기의 토큰만
         유효하도록 처리.
       - JwtAuthenticationFilter에서 이전 세션 토큰 접근 시
         AUTH-4012(TOKEN_VERSION_MISMATCH) 에러 반환.
   - 보안 설정 업데이트:
       - Swagger UI 및 API Docs 경로(/swagger, /api-docs 등)를 permitAll()에 추가하여
         인증 없이 접근 가능하도록 수정.
   - 엔티티 및 Audit 보완:
       - User 엔티티 생성 시 Audit 필드(createdAt 등)가 null이 되지 않도록 생성자 로직
         보완.

## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인 (로그인 -> API 호출 -> 재발급 -> 로그아웃)
- [x] 예외 케이스 확인 (잘못된 비번, 중복 로그인, 만료된 토큰)

### 확인 방법
  1. AuthServiceTest: 로그인 성공/실패, 로그아웃, 재발급 비즈니스 로직 단위 테스트
      통과.
  2. Swagger UI 테스트: /api/v1/swagger에 접속하여 실제 API 호출 및 응답(JSON) 규격
      확인 완료.

## ⚠️ 영향 범위 (해당 시 체크)
- [x] API 스펙 변경 (Auth 관련 3개 엔드포인트 추가)
- [ ] DB 스키마 변경
- [x] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정

## 👀 리뷰 포인트