### PR TITLE
[Feat] 주문 도메인 개선 및 상태 변경 기능 구현

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/order/application/provider/OrderDataFinder.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/provider/OrderDataFinder.java
@@ -7,7 +7,7 @@ import com.dfdt.delivery.domain.order.domain.entity.Order;
 import com.dfdt.delivery.domain.order.domain.enums.OrderErrorCode;
 import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
 import com.dfdt.delivery.domain.product.domain.entity.Product;
-import com.dfdt.delivery.domain.product.domain.repository.ProductRepository;
+import com.dfdt.delivery.domain.product.domain.repository.JpaProductRepository;
 import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.store.domain.enums.StoreErrorCode;
 import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
@@ -29,7 +29,7 @@ public class OrderDataFinder {
     private final StoreRepository storeRepository;
     private final AddressRepository addressRepository;
     private final UserRepository userRepository;
-    private final ProductRepository productRepository;
+    private final JpaProductRepository productRepository;
     private final OrderRepository orderRepository;
 
 
@@ -39,7 +39,7 @@ public class OrderDataFinder {
     }
 
     public Store findStore(UUID storeId) {
-        return storeRepository.findById(storeId)
+        return storeRepository.findByStoreIdAndNotDeleted(storeId)
                 .orElseThrow(() -> new BusinessException(StoreErrorCode.NOT_FOUND_STORE));
     }
 

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/checker/OrderPreConditionChecker.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/checker/OrderPreConditionChecker.java
@@ -11,6 +11,8 @@ import com.dfdt.delivery.domain.user.domain.entity.User;
 import com.dfdt.delivery.domain.user.domain.enums.UserRole;
 import org.springframework.stereotype.Component;
 
+import java.util.Objects;
+
 @Component
 public class OrderPreConditionChecker {
 
@@ -33,7 +35,8 @@ public class OrderPreConditionChecker {
     public void authoriseOrder(Order order, User user) {
         // 1. 고객인 경우: 본인 주문만 접근 가능
         if (user.getRole() == UserRole.CUSTOMER) {
-            if (!order.getUser().getUsername().equals(user.getUsername())) {
+            System.out.println(order.getUser().getUsername()+ user.getUsername());
+            if (!Objects.equals(order.getUser().getUsername(), user.getUsername())) {
                 throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
             }
         }
@@ -74,6 +77,31 @@ public class OrderPreConditionChecker {
         if (user.getRole() == UserRole.CUSTOMER) {
             authoriseOrder(order, user);
         }
-       throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
+       else throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
+    }
+
+    public void validateStatusUpdatable(User user, Order order,OrderStatus toStatus) {
+        OrderStatus nowStatus = order.getStatus();
+        if (user.getRole() == UserRole.CUSTOMER)
+        {
+            throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
+        }
+        // 결제 상태가 아니라면 바꿀 수 없음
+        if (nowStatus==OrderStatus.PENDING)
+        {
+            throw new BusinessException(OrderErrorCode.PAYMENT_REQUIRED);
+        }
+        // 이미 삭제 되었거나 완료되었으면
+        if (nowStatus == OrderStatus.COMPLETED
+                || nowStatus == OrderStatus.CANCELED
+                || nowStatus == OrderStatus.HIDDEN)
+            throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
+
+        // 같은 상태로는 못 바꾸고 이미 처리된 주문에 대해서는 못 바꿈
+        if (order.getStatus() == toStatus || isProcessing(order) && toStatus == OrderStatus.REJECTED)
+        {
+            throw  new BusinessException(OrderErrorCode.ALREADY_PROCESSED);
+        }
+
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandService.java
@@ -1,6 +1,7 @@
 package com.dfdt.delivery.domain.order.application.service.command;
 
 import com.dfdt.delivery.domain.order.presentation.dto.*;
+import jakarta.validation.Valid;
 
 import java.util.UUID;
 
@@ -8,4 +9,5 @@ public interface OrderCommandService {
     OrderResDto.OrderMutationResponse createOrder(String username, OrderReqDto.Create createDTO);
     OrderResDto.OrderMutationResponse updateOrder(String username, UUID orderId, OrderReqDto.UpdateOrder updateOrderDTO);
     Void deleteOrder(String username, UUID orderId);
+    OrderResDto.OrderMutationResponse updateOrderStatus(String username, UUID orderId, OrderReqDto.@Valid UpdateStatus updateStatusDTO);
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandServiceImpl.java
@@ -11,6 +11,7 @@ import com.dfdt.delivery.domain.order.domain.repository.OrderCacheManager;
 import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
+import com.dfdt.delivery.domain.payment.application.service.command.PaymentCommandService;
 import com.dfdt.delivery.domain.product.domain.entity.Product;
 import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.user.domain.entity.User;
@@ -28,6 +29,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
     private final OrderRepository orderRepository;
     private final OrderPreConditionChecker orderPreConditionChecker;
     private final OrderDataFinder orderDataFinder;
+    private final PaymentCommandService paymentCommandService;
 
 
     @Transactional
@@ -54,6 +56,8 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         }
         // DB 저장
         Order savedOrder = orderRepository.save(order);
+        // 결제 생성 로직 넣기
+        paymentCommandService.createPayment(null);
         // Redis TTL 설정하여 결제 대기 시간 제한
         orderCacheManager.setPaymentTimeout(savedOrder.getOrderId(), Duration.ofMinutes(5));
         // 응답 반환
@@ -117,5 +121,24 @@ public class OrderCommandServiceImpl implements OrderCommandService {
             order.updateStatus(OrderStatus.HIDDEN,"주문 목록에서 제거");
         order.deleteOrder(user.getName());
         return null;
+    }
+
+    @Transactional
+    @Override
+    public OrderResDto.OrderMutationResponse updateOrderStatus(String username, UUID orderId, OrderReqDto.UpdateStatus updateStatusDTO) {
+
+        // 정보 가져오기
+        Order order = orderDataFinder.findOrder(orderId);
+        User user = orderDataFinder.findUser(username);
+
+        // 전체 권한 체크
+        orderPreConditionChecker.authoriseOrder(order,user);
+        orderPreConditionChecker.validateStatusUpdatable(user,order,updateStatusDTO.orderStatus());
+
+        // 권한 수정
+        order.updateStatus(updateStatusDTO.orderStatus(), updateStatusDTO.changedReason());
+        Order saveOrder = orderRepository.save(order);
+
+        return OrderConverter.toMutationResponse(saveOrder);
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
@@ -35,12 +35,11 @@ public class OrderController implements OrderControllerDocs {
                 orderCommandService.createOrder(customUserDetails.getUsername(),createDTO)
         );
     }
-    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
 
     // API-002 사용자의 주문 목록 조회
-    @GetMapping("/{user_id}")
+    @GetMapping()
     public ResponseEntity<ApiResponseDto<OrderResDto.CustomerOrderResponse>> getOrders(
-            @PathVariable (value = "user_id") String userId
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
         return ApiResponseDto.success(
                 200,
@@ -48,13 +47,12 @@ public class OrderController implements OrderControllerDocs {
                 null
         );
     }
-    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
 
     // API-003 주문 상세 조회
-    @GetMapping("/{order_id}/{user_id}")
+    @GetMapping("/{orderId}")
     public ResponseEntity<ApiResponseDto<OrderResDto.GetOrderDetailResponse>> getOrderDetail(
-            @PathVariable (value = "order_id") String orderId,
-            @PathVariable (value = "user_id") String  userId
+            @PathVariable (value = "orderId") UUID orderId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ){
         return ApiResponseDto.success(
                 200,
@@ -64,9 +62,9 @@ public class OrderController implements OrderControllerDocs {
     }
 
     // API-004 주문 수정하기
-    @PatchMapping("/{order_id}")
+    @PatchMapping("/{orderId}")
     public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrder(
-            @PathVariable (value = "order_id") UUID orderId,
+            @PathVariable (value = "orderId") UUID orderId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody OrderReqDto.UpdateOrder updateDTO
     ) {
@@ -78,9 +76,9 @@ public class OrderController implements OrderControllerDocs {
     }
 
     // API-005 주문 삭제하기
-    @DeleteMapping("/{order_id}")
+    @DeleteMapping("/{orderId}")
     public ResponseEntity<ApiResponseDto<Void>> deleteOrder(
-            @PathVariable (value = "order_id") UUID orderId,
+            @PathVariable (value = "orderId") UUID orderId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         return ApiResponseDto.success(
@@ -89,27 +87,25 @@ public class OrderController implements OrderControllerDocs {
                 orderCommandService.deleteOrder(customUserDetails.getUsername(),orderId)
         );
     }
-    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
 
     // API-006 주문 상태 변경하기
-    @PatchMapping("/{order_id}/status/{user_id}")
+    @PatchMapping("/{orderId}/status")
     public ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrderStatus(
-            @PathVariable (value = "order_id") String orderId,
-            @PathVariable (value = "user_id") String  userId,
+            @PathVariable (value = "orderId") UUID orderId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody OrderReqDto.UpdateStatus updateStatusDTO
     ) {
         return ApiResponseDto.success(
                 200,
                 "주문 상태가 성공적으로 변경되었습니다.",
-                null
+                orderCommandService.updateOrderStatus(customUserDetails.getUsername(),orderId,updateStatusDTO)
         );
     }
-    // todo: AUTH로 바꾸기,UserDetail 생성 전까지 userId를 경로상에 포함시킵니다.
 
     // API-007 가게의 주문 목록 조회하기 ( 상태별 )
-    @GetMapping("/store/{store_id}")
+    @GetMapping("/store/{storeId}")
     public ResponseEntity<ApiResponseDto<OrderResDto.OwnerDashboardResponse>> getOrdersByOwner(
-            @PathVariable (value = "store_id") String  storeId
+            @PathVariable (value = "storeId") UUID  storeId
     ) {
         return ApiResponseDto.success(
                 200,

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
@@ -50,7 +50,7 @@ public interface OrderControllerDocs {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     ResponseEntity<ApiResponseDto<OrderResDto.CustomerOrderResponse>> getOrders(
-            @PathVariable(value = "user_id") String userId);
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
 
     @Operation(summary = "API-003 주문 상세 조회", description = "특정 주문에 대한 상세 정보를 조회합니다.")
@@ -64,8 +64,8 @@ public interface OrderControllerDocs {
             }))
     })
     ResponseEntity<ApiResponseDto<OrderResDto.GetOrderDetailResponse>> getOrderDetail(
-            @PathVariable(value = "order_id") String orderId,
-            @PathVariable(value = "user_id") String userId);
+            @PathVariable(value = "orderId") UUID orderId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
 
     @Operation(summary = "API-004 주문 수정하기", description = "배달지 정보나 요청사항 등 주문 내용을 수정합니다.")
@@ -82,7 +82,7 @@ public interface OrderControllerDocs {
             })),
     })
     ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrder(
-            @PathVariable(value = "order_id") UUID orderId,
+            @PathVariable(value = "orderId") UUID orderId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody OrderReqDto.UpdateOrder updateDTO
     );
@@ -102,7 +102,7 @@ public interface OrderControllerDocs {
             })),
     })
     ResponseEntity<ApiResponseDto<Void>> deleteOrder(
-            @PathVariable(value = "order_id") UUID orderId,
+            @PathVariable(value = "orderId") UUID orderId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
 
@@ -121,8 +121,8 @@ public interface OrderControllerDocs {
             })),
     })
     ResponseEntity<ApiResponseDto<OrderResDto.OrderMutationResponse>> updateOrderStatus(
-            @PathVariable(value = "order_id") String orderId,
-            @PathVariable(value = "user_id") String userId,
+            @PathVariable(value = "orderId") UUID orderId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
             @Valid @RequestBody OrderReqDto.UpdateStatus updateStatusDTO
     );
 
@@ -133,5 +133,5 @@ public interface OrderControllerDocs {
             @ApiResponse(responseCode = "404", description = "가게 정보를 찾을 수 없음")
     })
     ResponseEntity<ApiResponseDto<OrderResDto.OwnerDashboardResponse>> getOrdersByOwner(
-            @PathVariable(value = "store_id") String store_id);
+            @PathVariable(value = "storeId") UUID storeId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
@@ -1,6 +1,7 @@
 package com.dfdt.delivery.domain.order.presentation.dto;
 
 import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
+import com.dfdt.delivery.domain.payment.domain.enums.PaymentMethod;
 import jakarta.validation.constraints.*;
 import org.hibernate.validator.constraints.Length;
 
@@ -16,7 +17,9 @@ public class OrderReqDto {
             @NotEmpty(message = "하나 이상의 상품이 들어있어야 합니다.")
             List<OrderItem> orderItems,
             @Length(max = 255,message = "최대 255자 입니다.")
-            String requestMemo
+            String requestMemo,
+            @NotNull
+            PaymentMethod paymentMethod
     ){}
     public record OrderItem(
             @NotNull(message = "상품 아이디가 입력되지 않았습니다.")


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #4 

## 📌 작업 내용
이 PR에서 무엇을 변경했는지 간단히 작성합니다.

## ✅ 주요 변경 사항
- url 상의 PathVariable을 카멜 케이스로 변경하였습니다.
- product레포의 참조를 변경하였습니다.
- 주문 상태 변경 로직과 예외 처리를 구현하였습니다.

## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인
- [x] 예외 케이스 확인 (해당 시)

### 확인 방법 (선택)
1.  스웨거 동작 확인
2. 테이블 상태 변경 확인

**API Response (200 OK)**
<img width="1162" height="473" alt="image" src="https://github.com/user-attachments/assets/3d1b7732-79b1-4363-8f78-b30b5388810c" />

**예외 상황**
|에러코드|상황|확인|
|---|---|---|
|order-4002|이미 처리된 주문|✅|
|order-4010|접근 권한 없음|✅|
|order-4003|결제 대기중|✅|


## ⚠️ 영향 범위 (해당 시 체크)
- [x] API 스펙 변경
- [ ] DB 스키마 변경
- [x] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [x] 문서(Swagger/README) 수정

## 👀 리뷰 포인트 (선택)
리뷰어가 특히 봐줬으면 하는 부분이 있으면 작성합니다.
