### PR TITLE
[Feat] 결제 생성 및 타임 아웃 구현

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/payment/application/converter/PaymentConverter.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/converter/PaymentConverter.java
@@ -1,0 +1,40 @@
+package com.dfdt.delivery.domain.payment.application.converter;
+
+import com.dfdt.delivery.common.infrastructure.persistence.embedded.CreateAudit;
+import com.dfdt.delivery.common.infrastructure.persistence.embedded.SoftDeleteAudit;
+import com.dfdt.delivery.common.infrastructure.persistence.embedded.UpdateAudit;
+import com.dfdt.delivery.domain.payment.domain.entity.Payment;
+import com.dfdt.delivery.domain.payment.domain.enums.PaymentStatus;
+import com.dfdt.delivery.domain.payment.presentation.dto.request.PaymentCreateReqDto;
+import com.dfdt.delivery.domain.payment.presentation.dto.response.PaymentDetailResDto;
+
+public class PaymentConverter {
+
+    public static Payment toEntity(PaymentCreateReqDto reqDto, String username) {
+        return Payment.builder()
+                .orderId(reqDto.getOrderId())
+                .paymentMethod(reqDto.getPaymentMethod())
+                .paymentStatus(PaymentStatus.READY)
+                .amount(reqDto.getAmount())
+                .createAudit(CreateAudit.now(username))
+                .updateAudit(UpdateAudit.empty())
+                .softDeleteAudit(SoftDeleteAudit.active())
+                .build();
+    }
+
+    public static PaymentDetailResDto toDetailResDto(Payment payment) {
+        return PaymentDetailResDto.builder()
+                .paymentId(payment.getPaymentId())
+                .orderId(payment.getOrderId())
+                .status(payment.getPaymentStatus())
+                .amount(payment.getAmount().longValue())
+                .createdAt(payment.getCreateAudit().getCreatedAt())
+                .paidAt(payment.getPaidAt())
+                .failedAt(payment.getFailedAt())
+                .canceledAt(payment.getCanceledAt())
+                .failureReason(payment.getFailureReason())
+                .hidden(payment.isHidden())
+                .hiddenAt(payment.getHiddenAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/converter/PaymentConverter.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/converter/PaymentConverter.java
@@ -8,6 +8,8 @@ import com.dfdt.delivery.domain.payment.domain.enums.PaymentStatus;
 import com.dfdt.delivery.domain.payment.presentation.dto.request.PaymentCreateReqDto;
 import com.dfdt.delivery.domain.payment.presentation.dto.response.PaymentDetailResDto;
 
+import com.dfdt.delivery.domain.payment.domain.entity.PaymentStatusHistory;
+
 public class PaymentConverter {
 
     public static Payment toEntity(PaymentCreateReqDto reqDto, String username) {
@@ -36,5 +38,22 @@ public class PaymentConverter {
                 .hidden(payment.isHidden())
                 .hiddenAt(payment.getHiddenAt())
                 .build();
+    }
+
+    public static PaymentStatusHistory toStatusHistoryEntity(
+            Payment payment,
+            String username,
+            PaymentStatus from,
+            PaymentStatus to,
+            String reason
+    ) {
+        return PaymentStatusHistory.create(
+                payment.getPaymentId(),
+                payment.getOrderId(),
+                username,
+                from,
+                to,
+                reason
+        );
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandService.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandService.java
@@ -19,5 +19,5 @@ public interface PaymentCommandService {
 
     PaymentHiddenToggleResDto toggleHidden(UUID paymentId, Boolean hidden);
 
-    void failPayment(UUID orderId);
+    void timeoutPayment(UUID orderId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandService.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandService.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 
 public interface PaymentCommandService {
 
-    PaymentDetailResDto createPayment(PaymentCreateReqDto reqDto);
+    PaymentDetailResDto createPayment(PaymentCreateReqDto reqDto, String username);
 
     PaymentDetailResDto approvePayment(UUID paymentId, PaymentApproveReqDto reqDto);
 
@@ -18,4 +18,6 @@ public interface PaymentCommandService {
     void deletePayment(UUID paymentId);
 
     PaymentHiddenToggleResDto toggleHidden(UUID paymentId, Boolean hidden);
+
+    void failPayment(UUID orderId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
@@ -1,40 +1,106 @@
 package com.dfdt.delivery.domain.payment.application.service.command;
 
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.common.util.RedisService;
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.domain.enums.OrderErrorCode;
+import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
+import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
+import com.dfdt.delivery.domain.payment.application.converter.PaymentConverter;
+import com.dfdt.delivery.domain.payment.domain.entity.Payment;
+import com.dfdt.delivery.domain.payment.domain.entity.PaymentStatusHistory;
+import com.dfdt.delivery.domain.payment.domain.enums.PaymentErrorCode;
+import com.dfdt.delivery.domain.payment.domain.enums.PaymentStatus;
+import com.dfdt.delivery.domain.payment.domain.repository.PaymentRepository;
+import com.dfdt.delivery.domain.payment.domain.repository.PaymentStatusHistoryRepository;
 import com.dfdt.delivery.domain.payment.presentation.dto.request.PaymentApproveReqDto;
 import com.dfdt.delivery.domain.payment.presentation.dto.request.PaymentCreateReqDto;
 import com.dfdt.delivery.domain.payment.presentation.dto.response.PaymentDetailResDto;
 import com.dfdt.delivery.domain.payment.presentation.dto.response.PaymentHiddenToggleResDto;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
 @Service
+@RequiredArgsConstructor
 public class PaymentCommandServiceImpl implements PaymentCommandService {
 
+    private final PaymentRepository paymentRepository;
+    private final PaymentStatusHistoryRepository historyRepository;
+    private final OrderRepository orderRepository;
+    private final RedisService redisService;
+
+    private static final String TIMEOUT_KEY_PREFIX = "payment:timeout:";
+    private static final long FIVE_MINUTES_MS = 5 * 60 * 1000L;
+
     @Override
-    public PaymentDetailResDto createPayment(PaymentCreateReqDto reqDto) {
-        // TODO: 결제 생성
-        return null;
+    @Transactional
+    public PaymentDetailResDto createPayment(PaymentCreateReqDto reqDto, String username) {
+        Payment payment = PaymentConverter.toEntity(reqDto, username);
+        Payment savedPayment = paymentRepository.save(payment);
+
+        saveHistory(savedPayment, username, null, PaymentStatus.READY, "결제 생성");
+
+        // Redis TTL 설정 (5분)
+        redisService.setData(TIMEOUT_KEY_PREFIX + savedPayment.getOrderId(), "PENDING", FIVE_MINUTES_MS);
+
+        return PaymentConverter.toDetailResDto(savedPayment);
     }
 
     @Override
+    @Transactional
+    public void timeoutPayment(UUID orderId) {
+        Payment payment = paymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        if (payment.getPaymentStatus() != PaymentStatus.READY) {
+            return;
+        }
+
+        payment.markFailed("SYSTEM", "결제 시간 초과 (5분 경과)");
+        saveHistory(payment, "SYSTEM", PaymentStatus.READY, PaymentStatus.FAILED, "결제 타임아웃 자동 처리");
+
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        order.updateStatus(OrderStatus.CANCELED, "결제 시간 초과로 인한 자동 주문 취소");
+    }
+
+    private void saveHistory(Payment payment, String username, PaymentStatus from, PaymentStatus to, String reason) {
+        PaymentStatusHistory history = PaymentConverter.toStatusHistoryEntity(
+                payment,
+                username,
+                from,
+                to,
+                reason
+        );
+        historyRepository.save(history);
+    }
+
+    @Override
+    @Transactional
     public PaymentDetailResDto approvePayment(UUID paymentId, PaymentApproveReqDto reqDto) {
         // TODO: 결제 승인
         return null;
     }
 
     @Override
+    @Transactional
     public PaymentDetailResDto cancelPayment(UUID paymentId) {
         // TODO: 결제 취소
         return null;
     }
 
     @Override
+    @Transactional
     public void deletePayment(UUID paymentId) {
         // TODO: 결제 삭제
     }
 
     @Override
+    @Transactional
     public PaymentHiddenToggleResDto toggleHidden(UUID paymentId, Boolean hidden) {
         // TODO: 숨김 토글
         return null;

--- a/src/main/java/com/dfdt/delivery/domain/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/domain/repository/PaymentRepository.java
@@ -1,4 +1,12 @@
 package com.dfdt.delivery.domain.payment.domain.repository;
 
+import com.dfdt.delivery.domain.payment.domain.entity.Payment;
+
+import java.util.Optional;
+import java.util.UUID;
+
 public interface PaymentRepository {
+    Payment save(Payment payment);
+    Optional<Payment> findByOrderId(UUID orderId);
+    Optional<Payment> findById(UUID paymentId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/payment/domain/repository/PaymentStatusHistoryRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/domain/repository/PaymentStatusHistoryRepository.java
@@ -1,4 +1,7 @@
 package com.dfdt.delivery.domain.payment.domain.repository;
 
+import com.dfdt.delivery.domain.payment.domain.entity.PaymentStatusHistory;
+
 public interface PaymentStatusHistoryRepository {
+    PaymentStatusHistory save(PaymentStatusHistory history);
 }

--- a/src/main/java/com/dfdt/delivery/domain/payment/infrastructure/listener/PaymentTimeoutHandler.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/infrastructure/listener/PaymentTimeoutHandler.java
@@ -1,0 +1,37 @@
+package com.dfdt.delivery.domain.payment.infrastructure.listener;
+
+import com.dfdt.delivery.domain.payment.application.service.command.PaymentCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentTimeoutHandler implements MessageListener {
+
+    private final PaymentCommandService paymentCommandService;
+    private static final String TIMEOUT_KEY_PREFIX = "payment:timeout:";
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String expiredKey = message.toString();
+
+        // Expired 된 키가 "payment:timeout:{orderId}" 형식인 경우에만 처리합니다.
+        if (expiredKey.startsWith(TIMEOUT_KEY_PREFIX)) {
+            String orderIdStr = expiredKey.replace(TIMEOUT_KEY_PREFIX, "");
+            try {
+                UUID orderId = UUID.fromString(orderIdStr);
+                paymentCommandService.timeoutPayment(orderId);
+            } catch (IllegalArgumentException e) {
+                log.error("유효하지 않은 Order ID 형식입니다: {}", orderIdStr);
+            } catch (Exception e) {
+                log.error("결제 타임아웃 처리 중 예외 발생. OrderId: {}, Error: {}", orderIdStr, e.getMessage(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/payment/infrastructure/persistence/redis/PaymentRedisConfig.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/infrastructure/persistence/redis/PaymentRedisConfig.java
@@ -1,0 +1,24 @@
+package com.dfdt.delivery.domain.payment.infrastructure.persistence.redis;
+
+import com.dfdt.delivery.domain.payment.infrastructure.listener.PaymentTimeoutHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class PaymentRedisConfig {
+
+    @Bean
+    public RedisMessageListenerContainer paymentRedisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            PaymentTimeoutHandler timeoutHandler) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+
+        container.addMessageListener(timeoutHandler, new PatternTopic("__keyevent@*__:expired"));
+
+        return container;
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/payment/presentation/controller/PaymentCommandController.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/presentation/controller/PaymentCommandController.java
@@ -3,12 +3,10 @@ package com.dfdt.delivery.domain.payment.presentation.controller;
 import com.dfdt.delivery.common.response.ApiResponseDto;
 import com.dfdt.delivery.domain.payment.application.service.command.PaymentCommandService;
 import com.dfdt.delivery.domain.payment.presentation.dto.request.PaymentApproveReqDto;
-import com.dfdt.delivery.domain.payment.presentation.dto.request.PaymentCreateReqDto;
 import com.dfdt.delivery.domain.payment.presentation.dto.response.PaymentDetailResDto;
 import com.dfdt.delivery.domain.payment.presentation.dto.response.PaymentHiddenToggleResDto;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,15 +18,6 @@ import java.util.UUID;
 public class PaymentCommandController {
 
     private final PaymentCommandService paymentCommandService;
-
-    // 1. 결제 생성
-    @PostMapping
-    public ResponseEntity<ApiResponseDto<PaymentDetailResDto>> createPayment(
-            @RequestBody PaymentCreateReqDto reqDto) {
-
-        PaymentDetailResDto response = paymentCommandService.createPayment(reqDto);
-        return ApiResponseDto.success(201, "결제가 생성되었습니다.", response);
-    }
 
     // 2. 결제 승인
     @PostMapping("/{paymentId}/approve")

--- a/src/main/java/com/dfdt/delivery/domain/payment/presentation/dto/request/PaymentCreateReqDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/presentation/dto/request/PaymentCreateReqDto.java
@@ -2,6 +2,8 @@ package com.dfdt.delivery.domain.payment.presentation.dto.request;
 
 import com.dfdt.delivery.domain.payment.domain.enums.PaymentMethod;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +11,8 @@ import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class PaymentCreateReqDto {
 
     @NotNull(message = "주문 ID가 입력되지 않았습니다.")


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #10 

## 📌 작업 내용
- 결제 생성 (ttl 5분)
- 결제 실패 처리 (타임 아웃)
- 결제/결제 히스토리/주문 상태 변경
- Redis TTL 만료 이벤트 수신

## ✅ 주요 변경 사항
- 결제 타임아웃 로직 구현 (timeoutPayment): Redis TTL 만료 이벤트를 수신하여 5분 경과 시 결제 상태를 FAILED로, 주문 상태를 CANCELED로 자동 변경합니다.
- 이벤트 리스너 : PaymentTimeoutHandler를 통해 이벤트를 수신하고 결제 및 주문 취소로 상태 변경합니다.

## 🧪 테스트 / 확인 방법
- [ ] 로컬 실행 확인
- [ ] 주요 시나리오 동작 확인
- [ ] 예외 케이스 확인

## ⚠️ 영향 범위 (해당 시 체크)
- [ ] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정
