### PR TITLE
[Feat] 결제 command api 구현

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/payment/application/provider/PaymentDataFinder.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/provider/PaymentDataFinder.java
@@ -1,0 +1,27 @@
+package com.dfdt.delivery.domain.payment.application.provider;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.payment.domain.entity.Payment;
+import com.dfdt.delivery.domain.payment.domain.enums.PaymentErrorCode;
+import com.dfdt.delivery.domain.payment.domain.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentDataFinder {
+
+    private final PaymentRepository paymentRepository;
+
+    public Payment findPayment(UUID paymentId) {
+        return paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+    }
+
+    public Payment findPaymentByOrderId(UUID orderId) {
+        return paymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandService.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandService.java
@@ -11,13 +11,13 @@ public interface PaymentCommandService {
 
     PaymentDetailResDto createPayment(PaymentCreateReqDto reqDto, String username);
 
-    PaymentDetailResDto approvePayment(UUID paymentId, PaymentApproveReqDto reqDto);
+    PaymentDetailResDto approvePayment(UUID paymentId, PaymentApproveReqDto reqDto, String username);
 
-    PaymentDetailResDto cancelPayment(UUID paymentId);
+    PaymentDetailResDto cancelPayment(UUID paymentId, String username);
 
-    void deletePayment(UUID paymentId);
+    void deletePayment(UUID paymentId, String username);
 
-    PaymentHiddenToggleResDto toggleHidden(UUID paymentId, Boolean hidden);
+    PaymentHiddenToggleResDto toggleHidden(UUID paymentId, Boolean hidden, String username);
 
     void timeoutPayment(UUID orderId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
@@ -1,16 +1,14 @@
 package com.dfdt.delivery.domain.payment.application.service.command;
 
-import com.dfdt.delivery.common.exception.BusinessException;
 import com.dfdt.delivery.common.util.RedisService;
+import com.dfdt.delivery.domain.order.application.provider.OrderDataFinder;
 import com.dfdt.delivery.domain.order.domain.entity.Order;
-import com.dfdt.delivery.domain.order.domain.enums.OrderErrorCode;
 import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
-import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
 import com.dfdt.delivery.domain.payment.application.converter.PaymentConverter;
+import com.dfdt.delivery.domain.payment.application.provider.PaymentDataFinder;
 import com.dfdt.delivery.domain.payment.application.service.validator.PaymentValidator;
 import com.dfdt.delivery.domain.payment.domain.entity.Payment;
 import com.dfdt.delivery.domain.payment.domain.entity.PaymentStatusHistory;
-import com.dfdt.delivery.domain.payment.domain.enums.PaymentErrorCode;
 import com.dfdt.delivery.domain.payment.domain.enums.PaymentStatus;
 import com.dfdt.delivery.domain.payment.domain.repository.PaymentRepository;
 import com.dfdt.delivery.domain.payment.domain.repository.PaymentStatusHistoryRepository;
@@ -30,9 +28,10 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
 
     private final PaymentRepository paymentRepository;
     private final PaymentStatusHistoryRepository historyRepository;
-    private final OrderRepository orderRepository;
     private final RedisService redisService;
     private final PaymentValidator paymentValidator;
+    private final PaymentDataFinder paymentDataFinder;
+    private final OrderDataFinder orderDataFinder;
 
     private static final String TIMEOUT_KEY_PREFIX = "payment:timeout:";
     private static final long FIVE_MINUTES_MS = 5 * 60 * 1000L;
@@ -54,8 +53,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     @Override
     @Transactional
     public void timeoutPayment(UUID orderId) {
-        Payment payment = paymentRepository.findByOrderId(orderId)
-                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+        Payment payment = paymentDataFinder.findPaymentByOrderId(orderId);
 
         if (payment.getPaymentStatus() != PaymentStatus.READY) {
             return;
@@ -64,8 +62,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
         payment.markFailed("SYSTEM", "결제 시간 초과 (5분 경과)");
         saveHistory(payment, "SYSTEM", PaymentStatus.READY, PaymentStatus.FAILED, "결제 타임아웃 자동 처리");
 
-        Order order = orderRepository.findById(orderId)
-                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        Order order = orderDataFinder.findOrder(orderId);
 
         order.updateStatus(OrderStatus.CANCELED, "결제 시간 초과로 인한 자동 주문 취소");
     }
@@ -85,17 +82,15 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     @Transactional
     public PaymentDetailResDto approvePayment(UUID paymentId, PaymentApproveReqDto reqDto, String username) {
         // 1. 결제 데이터 조회
-        Payment payment = paymentRepository.findById(paymentId)
-                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+        Payment payment = paymentDataFinder.findPayment(paymentId);
 
         // 2. READY 상태일 때만 승인 가능
         paymentValidator.validateApproveCondition(payment);
 
         PaymentStatus fromStatus = payment.getPaymentStatus();
 
-        // 3. 주문 정보 조회 (상태 변경을 위해)
-        Order order = orderRepository.findById(payment.getOrderId())
-                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        // 3. 주문 정보 조회
+        Order order = orderDataFinder.findOrder(payment.getOrderId());
 
         if (reqDto.getResult() == PaymentStatus.PAID) {
             // 4-1. 승인 성공 처리
@@ -131,15 +126,13 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     @Transactional
     public PaymentDetailResDto cancelPayment(UUID paymentId, String username) {
         // 1. 결제 데이터 조회
-        Payment payment = paymentRepository.findById(paymentId)
-                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+        Payment payment = paymentDataFinder.findPayment(paymentId);
 
         // 2. 결제 상태 확인 (이미 취소되었거나 실패한 경우 제외)
         paymentValidator.validateCancelStatus(payment);
 
         // 3. 주문 정보 조회 및 상태 체크
-        Order order = orderRepository.findById(payment.getOrderId())
-                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        Order order = orderDataFinder.findOrder(payment.getOrderId());
 
         // PENDING, PAID 상태일 때만 취소 가능 (ACCEPTED 이후로는 취소 불가)
         paymentValidator.validateOrderCancelable(order);
@@ -162,8 +155,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     @Override
     @Transactional
     public void deletePayment(UUID paymentId, String username) {
-        Payment payment = paymentRepository.findById(paymentId)
-                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+        Payment payment = paymentDataFinder.findPayment(paymentId);
 
         payment.softDelete(username);
 
@@ -173,13 +165,13 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     @Override
     @Transactional
     public PaymentHiddenToggleResDto toggleHidden(UUID paymentId, Boolean isHidden, String username) {
-        Payment payment = paymentRepository.findById(paymentId)
-                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+        // 1. 결제 데이터 조회
+        Payment payment = paymentDataFinder.findPayment(paymentId);
 
-        Order order = orderRepository.findById(payment.getOrderId())
-                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        // 2. 주문 정보 조회
+        Order order = orderDataFinder.findOrder(payment.getOrderId());
 
-        // 주문 소유자 본인 확인
+        // 소유권 확인 (주문 소유자 본인 확인)
         paymentValidator.validateOwnership(order, username);
 
         if (Boolean.TRUE.equals(isHidden)) {

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
@@ -82,8 +82,49 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     @Override
     @Transactional
     public PaymentDetailResDto approvePayment(UUID paymentId, PaymentApproveReqDto reqDto, String username) {
-        // TODO: 결제 승인
-        return null;
+        // 1. 결제 데이터 조회
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        // 2. READY 상태일 때만 승인 가능
+        if (payment.getPaymentStatus() != PaymentStatus.READY) {
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+        }
+
+        PaymentStatus fromStatus = payment.getPaymentStatus();
+
+        // 3. 주문 정보 조회 (상태 변경을 위해)
+        Order order = orderRepository.findById(payment.getOrderId())
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        if (reqDto.getResult() == PaymentStatus.PAID) {
+            // 4-1. 승인 성공 처리
+            payment.markPaid(
+                    username,
+                    reqDto.getPgProvider(),
+                    reqDto.getPgTransactionId() != null ? reqDto.getPgTransactionId() : UUID.randomUUID().toString()
+            );
+            saveHistory(payment, username, fromStatus, PaymentStatus.PAID, "결제 승인 완료");
+
+            // 주문 상태를 PAID로 변경
+            order.updateStatus(OrderStatus.PAID, "결제 승인 완료로 인한 주문 상태 변경");
+
+            // Redis TTL 키 즉시 삭제 (타임아웃 방지)
+            redisService.deleteData(TIMEOUT_KEY_PREFIX + payment.getOrderId());
+        } else {
+            // 4-2. 승인 실패 처리
+            String reason = reqDto.getFailureReason() != null ? reqDto.getFailureReason() : "PG 승인 거절";
+            payment.markFailed(username, reason);
+            saveHistory(payment, username, fromStatus, PaymentStatus.FAILED, "결제 승인 거절: " + reason);
+
+            // 주문 상태를 CANCELED로 변경
+            order.updateStatus(OrderStatus.CANCELED, "결제 승인 거부로 인한 주문 취소");
+
+            // Redis TTL 키 삭제
+            redisService.deleteData(TIMEOUT_KEY_PREFIX + payment.getOrderId());
+        }
+
+        return PaymentConverter.toDetailResDto(payment);
     }
 
     @Override

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
@@ -130,8 +130,37 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     @Override
     @Transactional
     public PaymentDetailResDto cancelPayment(UUID paymentId, String username) {
-        // TODO: 결제 취소
-        return null;
+        // 1. 결제 데이터 조회
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        // 2. 결제 상태 확인 (이미 취소되었거나 실패한 경우 제외)
+        if (payment.getPaymentStatus() == PaymentStatus.CANCELED || payment.getPaymentStatus() == PaymentStatus.FAILED) {
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+        }
+
+        // 3. 주문 정보 조회 및 상태 체크
+        Order order = orderRepository.findById(payment.getOrderId())
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        // PENDING, PAID 상태일 때만 취소 가능 (ACCEPTED 이후로는 취소 불가)
+        if (order.getStatus() != OrderStatus.PENDING && order.getStatus() != OrderStatus.PAID) {
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+        }
+
+        PaymentStatus fromStatus = payment.getPaymentStatus();
+
+        // 4. 결제 상태 CANCELED 처리
+        payment.markCanceled(username, "사용자 요청으로 인한 취소");
+        saveHistory(payment, username, fromStatus, PaymentStatus.CANCELED, "사용자 요청 결제 취소");
+
+        // 5. 주문 상태 CANCELED 변경
+        order.updateStatus(OrderStatus.CANCELED, "결제 취소로 인한 주문 자동 취소");
+
+        // 6. Redis TTL 키 즉시 삭제
+        redisService.deleteData(TIMEOUT_KEY_PREFIX + payment.getOrderId());
+
+        return PaymentConverter.toDetailResDto(payment);
     }
 
     @Override

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
@@ -166,7 +166,12 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     @Override
     @Transactional
     public void deletePayment(UUID paymentId, String username) {
-        // TODO: 결제 삭제
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        payment.softDelete(username);
+
+        saveHistory(payment, username, payment.getPaymentStatus(), payment.getPaymentStatus(), "관리자에 의한 결제 내역 삭제");
     }
 
     @Override

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
@@ -176,8 +176,28 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
 
     @Override
     @Transactional
-    public PaymentHiddenToggleResDto toggleHidden(UUID paymentId, Boolean hidden, String username) {
-        // TODO: 숨김 토글
-        return null;
+    public PaymentHiddenToggleResDto toggleHidden(UUID paymentId, Boolean isHidden, String username) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+
+        Order order = orderRepository.findById(payment.getOrderId())
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+
+        // 주문 소유자 본인 확인
+        if (!order.getUser().getUsername().equals(username)) {
+            throw new BusinessException(PaymentErrorCode.ACCESS_DENIED);
+        }
+
+        if (isHidden) {
+            payment.hide(username);
+        } else {
+            payment.unhide(username);
+        }
+
+        return PaymentHiddenToggleResDto.builder()
+                .paymentId(payment.getPaymentId())
+                .hiddenAt(payment.getHiddenAt())
+                .hiddenBy(payment.getHiddenBy())
+                .build();
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
@@ -7,6 +7,7 @@ import com.dfdt.delivery.domain.order.domain.enums.OrderErrorCode;
 import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
 import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
 import com.dfdt.delivery.domain.payment.application.converter.PaymentConverter;
+import com.dfdt.delivery.domain.payment.application.service.validator.PaymentValidator;
 import com.dfdt.delivery.domain.payment.domain.entity.Payment;
 import com.dfdt.delivery.domain.payment.domain.entity.PaymentStatusHistory;
 import com.dfdt.delivery.domain.payment.domain.enums.PaymentErrorCode;
@@ -31,6 +32,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     private final PaymentStatusHistoryRepository historyRepository;
     private final OrderRepository orderRepository;
     private final RedisService redisService;
+    private final PaymentValidator paymentValidator;
 
     private static final String TIMEOUT_KEY_PREFIX = "payment:timeout:";
     private static final long FIVE_MINUTES_MS = 5 * 60 * 1000L;
@@ -87,9 +89,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
                 .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
         // 2. READY 상태일 때만 승인 가능
-        if (payment.getPaymentStatus() != PaymentStatus.READY) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
-        }
+        paymentValidator.validateApproveCondition(payment);
 
         PaymentStatus fromStatus = payment.getPaymentStatus();
 
@@ -135,18 +135,14 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
                 .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
         // 2. 결제 상태 확인 (이미 취소되었거나 실패한 경우 제외)
-        if (payment.getPaymentStatus() == PaymentStatus.CANCELED || payment.getPaymentStatus() == PaymentStatus.FAILED) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
-        }
+        paymentValidator.validateCancelStatus(payment);
 
         // 3. 주문 정보 조회 및 상태 체크
         Order order = orderRepository.findById(payment.getOrderId())
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
         // PENDING, PAID 상태일 때만 취소 가능 (ACCEPTED 이후로는 취소 불가)
-        if (order.getStatus() != OrderStatus.PENDING && order.getStatus() != OrderStatus.PAID) {
-            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
-        }
+        paymentValidator.validateOrderCancelable(order);
 
         PaymentStatus fromStatus = payment.getPaymentStatus();
 
@@ -184,11 +180,9 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
                 .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
 
         // 주문 소유자 본인 확인
-        if (!order.getUser().getUsername().equals(username)) {
-            throw new BusinessException(PaymentErrorCode.ACCESS_DENIED);
-        }
+        paymentValidator.validateOwnership(order, username);
 
-        if (isHidden) {
+        if (Boolean.TRUE.equals(isHidden)) {
             payment.hide(username);
         } else {
             payment.unhide(username);

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
@@ -81,27 +81,27 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
 
     @Override
     @Transactional
-    public PaymentDetailResDto approvePayment(UUID paymentId, PaymentApproveReqDto reqDto) {
+    public PaymentDetailResDto approvePayment(UUID paymentId, PaymentApproveReqDto reqDto, String username) {
         // TODO: 결제 승인
         return null;
     }
 
     @Override
     @Transactional
-    public PaymentDetailResDto cancelPayment(UUID paymentId) {
+    public PaymentDetailResDto cancelPayment(UUID paymentId, String username) {
         // TODO: 결제 취소
         return null;
     }
 
     @Override
     @Transactional
-    public void deletePayment(UUID paymentId) {
+    public void deletePayment(UUID paymentId, String username) {
         // TODO: 결제 삭제
     }
 
     @Override
     @Transactional
-    public PaymentHiddenToggleResDto toggleHidden(UUID paymentId, Boolean hidden) {
+    public PaymentHiddenToggleResDto toggleHidden(UUID paymentId, Boolean hidden, String username) {
         // TODO: 숨김 토글
         return null;
     }

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/validator/PaymentValidator.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/validator/PaymentValidator.java
@@ -1,0 +1,49 @@
+package com.dfdt.delivery.domain.payment.application.service.validator;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.payment.domain.entity.Payment;
+import com.dfdt.delivery.domain.payment.domain.enums.PaymentErrorCode;
+import com.dfdt.delivery.domain.payment.domain.enums.PaymentStatus;
+import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PaymentValidator {
+
+    /**
+     * 결제 승인 가능 여부 검증 (상태가 READY여야 함)
+     */
+    public void validateApproveCondition(Payment payment) {
+        if (payment.getPaymentStatus() != PaymentStatus.READY) {
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+        }
+    }
+
+    /**
+     * 결제 취소 가능 여부 검증 (이미 취소되었거나 실패한 상태가 아니어야 함)
+     */
+    public void validateCancelStatus(Payment payment) {
+        if (payment.getPaymentStatus() == PaymentStatus.CANCELED || payment.getPaymentStatus() == PaymentStatus.FAILED) {
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+        }
+    }
+
+    /**
+     * 주문 상태 기반 취소 가능 여부 검증 (PENDING 또는 PAID 상태에서만 취소 가능)
+     */
+    public void validateOrderCancelable(Order order) {
+        if (order.getStatus() != OrderStatus.PENDING && order.getStatus() != OrderStatus.PAID) {
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);
+        }
+    }
+
+    /**
+     * 결제 내역 접근 권한 검증 (주문 소유자 본인 확인)
+     */
+    public void validateOwnership(Order order, String username) {
+        if (!order.getUser().getUsername().equals(username)) {
+            throw new BusinessException(PaymentErrorCode.ACCESS_DENIED);
+        }
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/payment/presentation/controller/PaymentCommandController.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/presentation/controller/PaymentCommandController.java
@@ -10,6 +10,7 @@ import com.dfdt.delivery.domain.payment.presentation.dto.response.PaymentHiddenT
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,7 +23,6 @@ public class PaymentCommandController {
 
     private final PaymentCommandService paymentCommandService;
 
-    // 2. 결제 승인
     @PostMapping("/{paymentId}/approve")
     public ResponseEntity<ApiResponseDto<PaymentDetailResDto>> approvePayment(
             @PathVariable UUID paymentId,
@@ -35,7 +35,6 @@ public class PaymentCommandController {
         return ApiResponseDto.success(200, "결제가 승인되었습니다.", response);
     }
 
-    // 3. 결제 취소
     @PostMapping("/{paymentId}/cancel")
     public ResponseEntity<ApiResponseDto<PaymentDetailResDto>> cancelPayment(
             @PathVariable UUID paymentId,
@@ -45,7 +44,7 @@ public class PaymentCommandController {
         return ApiResponseDto.success(200, "결제가 취소되었습니다.", response);
     }
 
-    // 4. 결제 삭제
+    @PreAuthorize("hasRole('MASTER')")
     @DeleteMapping("/{paymentId}")
     public ResponseEntity<ApiResponseDto<Void>> deletePayment(
             @PathVariable UUID paymentId,
@@ -55,7 +54,6 @@ public class PaymentCommandController {
         return ApiResponseDto.success(200, "결제가 삭제되었습니다.", null);
     }
 
-    // 5. 결제 숨김 토글
     @PostMapping("/{paymentId}/hidden")
     public ResponseEntity<ApiResponseDto<PaymentHiddenToggleResDto>> toggleHidden(
             @PathVariable UUID paymentId,

--- a/src/main/java/com/dfdt/delivery/domain/payment/presentation/controller/PaymentCommandController.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/presentation/controller/PaymentCommandController.java
@@ -1,13 +1,16 @@
 package com.dfdt.delivery.domain.payment.presentation.controller;
 
 import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
 import com.dfdt.delivery.domain.payment.application.service.command.PaymentCommandService;
 import com.dfdt.delivery.domain.payment.presentation.dto.request.PaymentApproveReqDto;
 import com.dfdt.delivery.domain.payment.presentation.dto.response.PaymentDetailResDto;
 import com.dfdt.delivery.domain.payment.presentation.dto.response.PaymentHiddenToggleResDto;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.UUID;
@@ -23,25 +26,32 @@ public class PaymentCommandController {
     @PostMapping("/{paymentId}/approve")
     public ResponseEntity<ApiResponseDto<PaymentDetailResDto>> approvePayment(
             @PathVariable UUID paymentId,
-            @RequestBody PaymentApproveReqDto reqDto) {
+            @Valid @RequestBody PaymentApproveReqDto reqDto,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        PaymentDetailResDto response = paymentCommandService.approvePayment(paymentId, reqDto);
+        PaymentDetailResDto response = paymentCommandService.approvePayment(
+                paymentId, reqDto, customUserDetails.getUsername()
+        );
         return ApiResponseDto.success(200, "결제가 승인되었습니다.", response);
     }
 
     // 3. 결제 취소
     @PostMapping("/{paymentId}/cancel")
     public ResponseEntity<ApiResponseDto<PaymentDetailResDto>> cancelPayment(
-            @PathVariable UUID paymentId) {
+            @PathVariable UUID paymentId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        PaymentDetailResDto response = paymentCommandService.cancelPayment(paymentId);
+        PaymentDetailResDto response = paymentCommandService.cancelPayment(paymentId, customUserDetails.getUsername());
         return ApiResponseDto.success(200, "결제가 취소되었습니다.", response);
     }
 
     // 4. 결제 삭제
     @DeleteMapping("/{paymentId}")
-    public ResponseEntity<ApiResponseDto<Void>> deletePayment(@PathVariable UUID paymentId) {
-        paymentCommandService.deletePayment(paymentId);
+    public ResponseEntity<ApiResponseDto<Void>> deletePayment(
+            @PathVariable UUID paymentId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        paymentCommandService.deletePayment(paymentId, customUserDetails.getUsername());
         return ApiResponseDto.success(200, "결제가 삭제되었습니다.", null);
     }
 
@@ -49,10 +59,11 @@ public class PaymentCommandController {
     @PostMapping("/{paymentId}/hidden")
     public ResponseEntity<ApiResponseDto<PaymentHiddenToggleResDto>> toggleHidden(
             @PathVariable UUID paymentId,
-            @RequestParam Boolean hidden) {
+            @RequestParam Boolean isHidden,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        PaymentHiddenToggleResDto response = paymentCommandService.toggleHidden(paymentId, hidden);
-        String msg = hidden ? "결제 내역이 숨김 처리되었습니다." : "결제 내역 숨김이 해제되었습니다.";
+        PaymentHiddenToggleResDto response = paymentCommandService.toggleHidden(paymentId, isHidden, customUserDetails.getUsername());
+        String msg = isHidden ? "결제 내역이 숨김 처리되었습니다." : "결제 내역 숨김이 해제되었습니다.";
         return ApiResponseDto.success(200, msg, response);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #39 

## 📌 작업 내용
PAYMENT 도메인의 결제 승인, 취소, 삭제, 숨김 API를 구현하였습니다. 또한, 코드 품질 향상과 유지보수성 확보를 위해 검증(Validator) 및 조회(Finder) 레이어를 분리하는 리팩토링을 함께 진행하였습니다.

## ✅ 주요 변경 사항
- 결제 승인 및 취소 로직 구현: 결제 상태 변경 시 연관된 주문(Order)의 상태를 자동으로 동기화하고, Redis의 결제 타임아웃 키를 즉시 삭제하도록 구현하였습니다.
- 권한별 차등 액션 적용: 결제 내역 삭제는 MASTER 권한만 가능하도록 제한하였으며, 일반 사용자는 내역 삭제 대신 '숨김(Toggle)' 기능을 사용하도록 구현하였습니다.
- PaymentValidator 도입: 서비스 레이어에 흩어져 있던 복잡한 검증 로직(상태 체크, 소유권 확인 등)을 전담 클래스로 분리하여 가독성을 높였습니다.
- PaymentDataFinder 도입: 엔티티 조회 및 존재하지 않을 경우의 예외 처리 로직을 표준화하여 서비스 코드의 중복을 제거하였습니다.

## 🧪 테스트 / 확인 방법
- [ ] 로컬 실행 확인
- [ ] 주요 시나리오 동작 확인
- [ ] 예외 케이스 확인

## ⚠️ 영향 범위 (해당 시 체크)
- [x] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정
