### PR TITLE
[Feat] 주문 Redis TTL 발행 및 이벤트 처리 로직 구현

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -6,8 +6,9 @@ services:
       - 'POSTGRES_PASSWORD=secret'
       - 'POSTGRES_USER=myuser'
     ports:
-      - '5432'
+      - '5432:5432'
   redis:
     image: 'redis:latest'
     ports:
-      - '6379'
+      - '6379:6379'
+    command: redis-server --notify-keyspace-events Ex

--- a/src/main/java/com/dfdt/delivery/common/config/RedisConfig.java
+++ b/src/main/java/com/dfdt/delivery/common/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -22,5 +23,11 @@ public class RedisConfig {
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return template;
+    }
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+        return container;
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/OrderExpirationService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/OrderExpirationService.java
@@ -41,7 +41,7 @@ public class OrderExpirationService {
     }
 
     /**
-     * [1] 결제 시간 초과 이벤트 처리 (5분 만료)
+     * [1] 결제 시간 초과 이벤트 처리 (10분 만료)
      */
     @EventListener
     @Transactional

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/OrderExpirationService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/OrderExpirationService.java
@@ -8,6 +8,7 @@ import com.dfdt.delivery.domain.order.domain.event.OrderEvent;
 import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
 import com.dfdt.delivery.domain.order.infrastructure.persistence.redis.OrderRedisService;
 import com.dfdt.delivery.domain.payment.application.service.command.PaymentCommandService;
+import com.dfdt.delivery.domain.payment.domain.enums.PaymentErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -72,17 +73,19 @@ public class OrderExpirationService {
         // 가게 미접수 처리 , 환불
         orderRepository.findByIdWithLock(event.orderId())
                 .ifPresent(order -> {
-                    if (order.getStatus().ordinal() < OrderStatus.ACCEPTED.ordinal())
+                    if (order.getStatus().isBeforeAcceptance())
                     {
                         // 주문 상태를 REJECTED로 변경
                         order.updateStatus(OrderStatus.REJECTED, "주문 후 가게 미수락 취소");
 
                         // 결제 정보 조회 및 환불 로직 실행
                         orderRepository.findPaymentOrderId(event.orderId())
-                                .ifPresent(payment -> {
+                                .ifPresentOrElse(payment -> {
                                     log.info("결제 취소 요청 실행: 결제ID {}", payment.getPaymentId());
                                     paymentCommandService.cancelPayment(payment.getPaymentId());
-                                });
+                                }
+                                , () -> {
+                                    throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);});
                     }
                 });
     }

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/OrderExpirationService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/OrderExpirationService.java
@@ -1,0 +1,89 @@
+package com.dfdt.delivery.domain.order.application.service;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.domain.enums.OrderErrorCode;
+import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
+import com.dfdt.delivery.domain.order.domain.event.OrderEvent;
+import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
+import com.dfdt.delivery.domain.order.infrastructure.persistence.redis.OrderRedisService;
+import com.dfdt.delivery.domain.payment.application.service.command.PaymentCommandService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrderExpirationService {
+
+    private final OrderRepository orderRepository;
+    private final PaymentCommandService paymentCommandService;
+    private final OrderRedisService orderRedisService;
+
+    @Transactional
+    public void completePayment(UUID orderId) {
+        // 1. 주문 상태를 PAID로 변경
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new BusinessException(OrderErrorCode.ORDER_NOT_FOUND));
+        order.updateStatus(OrderStatus.PAID, "결제 완료");
+
+        // 2. 기존  TTL 삭제
+        orderRedisService.cancelTimeOut(orderId);
+
+        // 3. 사장님 수락 대기(10분) TTL 생성
+        orderRedisService.setAcceptTimeout(orderId);
+        log.info("주문 {}번: 결제 완료 처리 및 사장님 수락 타이머 시작", orderId);
+    }
+
+    /**
+     * [1] 결제 시간 초과 이벤트 처리 (5분 만료)
+     */
+    @EventListener
+    @Transactional
+    public void handlePaymentTimeout(OrderEvent.PaymentTimeout event) {
+        log.info("결제 시간 초과로 인한 주문 취소 처리: {}", event.orderId());
+
+        // 주문을 찾아서 '결제 시간 초과 취소' 상태로 변경
+        orderRepository.findById(event.orderId())
+                .ifPresent(order ->
+                        {
+                            if (order.getStatus() == OrderStatus.PENDING)
+                                order.updateStatus(OrderStatus.REJECTED,"결제 대기 시간 초과");
+                            // 결제된 상태로 남아 있다면 가게 수락 TTL
+                            if (order.getStatus() == OrderStatus.PAID)
+                                orderRedisService.setAcceptTimeout(order.getOrderId());
+                        });
+
+    }
+
+    /**
+     * [2] 사장님 접수 시간 초과 이벤트 처리 (10분 만료)
+     */
+    @EventListener
+    @Transactional
+    public void handleAcceptanceTimeout(OrderEvent.AcceptanceTimeout event) {
+        log.info("사장님 미접수로 인한 주문 취소 처리: {}", event.orderId());
+
+        // 가게 미접수 처리 , 환불
+        orderRepository.findByIdWithLock(event.orderId())
+                .ifPresent(order -> {
+                    if (order.getStatus().ordinal() < OrderStatus.ACCEPTED.ordinal())
+                    {
+                        // 주문 상태를 REJECTED로 변경
+                        order.updateStatus(OrderStatus.REJECTED, "주문 후 가게 미수락 취소");
+
+                        // 결제 정보 조회 및 환불 로직 실행
+                        orderRepository.findPaymentOrderId(event.orderId())
+                                .ifPresent(payment -> {
+                                    log.info("결제 취소 요청 실행: 결제ID {}", payment.getPaymentId());
+                                    paymentCommandService.cancelPayment(payment.getPaymentId());
+                                });
+                    }
+                });
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/checker/OrderPreConditionChecker.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/checker/OrderPreConditionChecker.java
@@ -50,7 +50,8 @@ public class OrderPreConditionChecker {
         // 관리자(ADMIN)는 위 조건들에 걸리지 않으므로 모든 권한을 가짐 (자동 통과)
     }
     public void validateModifiable(Order order) {
-        if (order.getStatus().ordinal() >= OrderStatus.PAID.ordinal()) {
+        // 결제 완료(Step 2) 이상이면 수정 불가
+        if (order.getStatus().getStep() >= OrderStatus.PAID.getStep()) {
             throw new BusinessException(OrderErrorCode.ALREADY_PROCESSED);
         }
     }
@@ -60,18 +61,16 @@ public class OrderPreConditionChecker {
     }
 
     public void validateDeletable(Order order) {
-        // (예: 결제완료, 상품준비중, 배송중 등)
         if (isProcessing(order)) {
             throw new BusinessException(OrderErrorCode.ALREADY_PROCESSED);
         }
     }
     private boolean isProcessing(Order order) {
         OrderStatus status = order.getStatus();
-        // PAID(결제완료) 보다는 크거나 같고, COMPLETED(배송완료) 보다는 작은 상태들
-        return status.ordinal() >= OrderStatus.PAID.ordinal()
-                && status.ordinal() < OrderStatus.COMPLETED.ordinal();
+        // PAID(2) <= 현재 단계 < COMPLETED(7) 인 경우 진행 중으로 판단
+        return status.getStep() >= OrderStatus.PAID.getStep()
+                && status.getStep() < OrderStatus.COMPLETED.getStep();
     }
-
     public void authoriseOrderCustomer(Order order, User user) {
         if (user.getRole() == UserRole.CUSTOMER) {
             authoriseOrder(order, user);
@@ -79,29 +78,33 @@ public class OrderPreConditionChecker {
        else throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
     }
 
-    public void validateStatusUpdatable(User user, Order order,OrderStatus toStatus) {
+    public void validateStatusUpdatable(User user, Order order, OrderStatus toStatus) {
+        OrderStatus nowStatus = getOrderStatus(user, order);
+
+        // 동일 상태 변경 방지 및 진행 중인 주문 거절 방지
+        // 이미 사장님이 수락(ACCEPTED, Step 3)하여 진행 중인데 거절(REJECTED)하려는 경우 방지
+        if (nowStatus == toStatus || (nowStatus.getStep() >= OrderStatus.ACCEPTED.getStep() && toStatus == OrderStatus.REJECTED)) {
+            throw new BusinessException(OrderErrorCode.ALREADY_PROCESSED);
+        }
+    }
+
+    private static OrderStatus getOrderStatus(User user, Order order) {
         OrderStatus nowStatus = order.getStatus();
-        if (user.getRole() == UserRole.CUSTOMER)
-        {
+
+        // 1. 권한 체크
+        if (user.getRole() == UserRole.CUSTOMER) {
             throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
         }
-        // 결제 상태가 아니라면 바꿀 수 없음
-        if (nowStatus==OrderStatus.PENDING)
-        {
+
+        // 2. 기초 상태 체크
+        if (nowStatus == OrderStatus.PENDING) {
             throw new BusinessException(OrderErrorCode.PAYMENT_REQUIRED);
         }
-        // 이미 삭제 되었거나 완료되었으면
-        if (nowStatus == OrderStatus.COMPLETED
-                || nowStatus == OrderStatus.REJECTED
-                || nowStatus == OrderStatus.CANCELED
-                || nowStatus == OrderStatus.HIDDEN)
+
+        // 3. 종료된 주문 체크 (isTerminated 활용)
+        if (nowStatus.isTerminated()) {
             throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
-
-        // 같은 상태로는 못 바꾸고 이미 처리된 주문에 대해서는 못 바꿈
-        if (order.getStatus() == toStatus || isProcessing(order) && toStatus == OrderStatus.REJECTED)
-        {
-            throw  new BusinessException(OrderErrorCode.ALREADY_PROCESSED);
         }
-
+        return nowStatus;
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/checker/OrderPreConditionChecker.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/checker/OrderPreConditionChecker.java
@@ -60,7 +60,6 @@ public class OrderPreConditionChecker {
     }
 
     public void validateDeletable(Order order) {
-        // PAID(결제완료) 이상이면서 COMPLETED(배송완료)가 아닌 '진행 중'인 상태일 때
         // (예: 결제완료, 상품준비중, 배송중 등)
         if (isProcessing(order)) {
             throw new BusinessException(OrderErrorCode.ALREADY_PROCESSED);
@@ -93,6 +92,7 @@ public class OrderPreConditionChecker {
         }
         // 이미 삭제 되었거나 완료되었으면
         if (nowStatus == OrderStatus.COMPLETED
+                || nowStatus == OrderStatus.REJECTED
                 || nowStatus == OrderStatus.CANCELED
                 || nowStatus == OrderStatus.HIDDEN)
             throw new BusinessException(OrderErrorCode.ACCESS_DENIED);

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandServiceImpl.java
@@ -7,11 +7,12 @@ import com.dfdt.delivery.domain.order.application.service.checker.OrderPreCondit
 import com.dfdt.delivery.domain.order.domain.entity.Order;
 import com.dfdt.delivery.domain.order.domain.entity.OrderItem;
 import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
-import com.dfdt.delivery.domain.order.domain.repository.OrderCacheManager;
+import com.dfdt.delivery.domain.order.infrastructure.persistence.redis.OrderRedisService;
 import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
 import com.dfdt.delivery.domain.payment.application.service.command.PaymentCommandService;
+import com.dfdt.delivery.domain.payment.presentation.dto.request.PaymentCreateReqDto;
 import com.dfdt.delivery.domain.product.domain.entity.Product;
 import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.user.domain.entity.User;
@@ -25,7 +26,7 @@ import java.util.*;
 @Service
 @RequiredArgsConstructor
 public class OrderCommandServiceImpl implements OrderCommandService {
-    private final OrderCacheManager orderCacheManager;
+    private final OrderRedisService orderRedisService;
     private final OrderRepository orderRepository;
     private final OrderPreConditionChecker orderPreConditionChecker;
     private final OrderDataFinder orderDataFinder;
@@ -57,9 +58,13 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         // DB 저장
         Order savedOrder = orderRepository.save(order);
         // 결제 생성 로직 넣기
-        paymentCommandService.createPayment(null);
+        paymentCommandService.createPayment(
+                PaymentCreateReqDto.builder().orderId(savedOrder.getOrderId())
+                        .amount(savedOrder.getTotalPrice())
+                        .paymentMethod(createDTO.paymentMethod()).build(),
+                username);
         // Redis TTL 설정하여 결제 대기 시간 제한
-        orderCacheManager.setPaymentTimeout(savedOrder.getOrderId(), Duration.ofMinutes(5));
+        orderRedisService.setPaymentTimeout(savedOrder.getOrderId());
         // 응답 반환
         return OrderConverter.toMutationResponse(savedOrder);
     }
@@ -80,23 +85,6 @@ public class OrderCommandServiceImpl implements OrderCommandService {
             Address orderAddress = orderDataFinder.findAddress(updateOrderDTO.addressId());
             order.updateAddress(orderAddress);
         }
-        // 주문 상품 처리
-        order.removeOrderItems(updateOrderDTO.removeOrderItemIds());
-        if (updateOrderDTO.addOrderItems()!=null && !updateOrderDTO.addOrderItems().isEmpty()) {
-            List<UUID> productIds = updateOrderDTO.addOrderItems().stream().map(OrderReqDto.OrderItem::productId).toList();
-            Map<UUID, Product> stockMap = orderDataFinder.getProductMap(productIds);
-            for (OrderReqDto.OrderItem productItem : updateOrderDTO.addOrderItems()) {
-                Product stock = stockMap.get(productItem.productId());
-                // 매장의 상품이 존재하는 지, 재고가 있는지 확인하는 함수
-                orderPreConditionChecker.validateProduct(stock, order.getStore(), productItem);
-                // 주문 아이템 생성
-                OrderItem orderItem = OrderConverter.toOrderItem(stock, productItem.quantity());
-                order.addOrderItem(orderItem);
-            }
-        }
-        // 주문 상품 처리 후 상품 리스트에 상품이 하나도 안 남았다면 오류
-        orderPreConditionChecker.validateQuantity(order);
-
         if (updateOrderDTO.requestMemo()!=null)
             order.updateOrderMessage(updateOrderDTO.requestMemo());
         Order savedOrder = orderRepository.save(order);

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandServiceImpl.java
@@ -12,6 +12,7 @@ import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
 import com.dfdt.delivery.domain.payment.application.service.command.PaymentCommandService;
+import com.dfdt.delivery.domain.payment.domain.entity.Payment;
 import com.dfdt.delivery.domain.payment.presentation.dto.request.PaymentCreateReqDto;
 import com.dfdt.delivery.domain.product.domain.entity.Product;
 import com.dfdt.delivery.domain.store.domain.entity.Store;
@@ -123,6 +124,13 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         orderPreConditionChecker.authoriseOrder(order,user);
         orderPreConditionChecker.validateStatusUpdatable(user,order,updateStatusDTO.orderStatus());
 
+        if (order.getStatus() == OrderStatus.PAID && updateStatusDTO.orderStatus() == OrderStatus.REJECTED)
+        {
+            orderRepository.findPaymentOrderId(orderId)
+                    .ifPresent(payment -> {
+                        paymentCommandService.cancelPayment(payment.getPaymentId());
+                    });
+        }
         // 권한 수정
         order.updateStatus(updateStatusDTO.orderStatus(), updateStatusDTO.changedReason());
         Order saveOrder = orderRepository.save(order);

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/enums/OrderRedisPrefix.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/enums/OrderRedisPrefix.java
@@ -1,0 +1,43 @@
+package com.dfdt.delivery.domain.order.domain.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.UUID;
+
+@Getter
+@RequiredArgsConstructor
+public enum OrderRedisPrefix {
+    ORDER_PENDING("order:pending:%s", Duration.ofMinutes(10)),
+    OWNER_CONFIRM("order:accept:%s",Duration.ofMinutes(10));
+
+    private final String prefix;
+    private final Duration ttl;
+    
+    // 템플릿 생성
+    public String generateKey(Object id) {
+        return String.format(this.prefix, id.toString());
+    }
+    
+    // 아이디 추출
+    public UUID parseId(String fullKey) {
+        String prefixOnly = this.prefix.replace("%s", "");
+        String key = fullKey.replace(prefixOnly, "");
+        return UUID.fromString(key);
+    }
+    
+    // 키가 맞는지 확인
+    public boolean isMatched(String key) {
+        String prefixOnly = this.prefix.replace("%s", "");
+        return key.startsWith(prefixOnly);
+    }
+    // 어떤 ENUM 사용하는 지 확인
+    public static OrderRedisPrefix fromKey(String fullKey) {
+        return Arrays.stream(OrderRedisPrefix.values())
+                .filter(p -> p.isMatched(fullKey))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/enums/OrderStatus.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/enums/OrderStatus.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum OrderStatus {
-    PENDING, PAID, ACCEPTED, REJECTED,
+    PENDING, PAID, ACCEPTED,
     COOKING_DONE, DELIVERING, DELIVERED,
-    COMPLETED, CANCELED, HIDDEN
+    COMPLETED, REJECTED, CANCELED, HIDDEN;
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/enums/OrderStatus.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/enums/OrderStatus.java
@@ -6,7 +6,31 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum OrderStatus {
-    PENDING, PAID, ACCEPTED,
-    COOKING_DONE, DELIVERING, DELIVERED,
-    COMPLETED, REJECTED, CANCELED, HIDDEN;
+    
+    // 진행 단계, 설명
+    PENDING(1, "결제 대기"),
+    PAID(2, "결제 완료"),
+    ACCEPTED(3, "주문 수락(조리 중)"),
+    COOKING_DONE(4, "조리 완료"),
+    DELIVERING(5, "배달 중"),
+    DELIVERED(6, "배달 완료"),
+    COMPLETED(7, "주문 확정"),
+
+    // 프로세스 종료 상태 (Step 0 이하)
+    REJECTED(0, "주문 거절"),
+    CANCELED(0, "주문 취소"),
+    HIDDEN(-1, "숨김(사용자 삭제) 처리");
+
+    private final int step;
+    private final String description;
+
+    // 사장님 수락 전인지 확인 (결제 대기, 결제 완료 포함)
+    public boolean isBeforeAcceptance() {
+        return this.step > 0 && this.step < ACCEPTED.getStep();
+    }
+
+    // 이미 프로세스가 종료된 상태인지 확인
+    public boolean isTerminated() {
+        return this.step <= 0 || this == COMPLETED;
+    }
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/event/OrderEvent.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/event/OrderEvent.java
@@ -1,0 +1,14 @@
+package com.dfdt.delivery.domain.order.domain.event;
+
+import java.util.UUID;
+
+/**
+ * 주문 관련 Redis TTL 만료 이벤트를 모아두는 클래스
+ */
+public class OrderEvent {
+
+    public record PaymentTimeout(UUID orderId) {
+    }
+    public record AcceptanceTimeout(UUID orderId) {
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderCacheManager.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderCacheManager.java
@@ -1,9 +1,0 @@
-package com.dfdt.delivery.domain.order.domain.repository;
-
-
-import java.time.Duration;
-import java.util.UUID;
-
-public interface OrderCacheManager {
-    void setPaymentTimeout(UUID orderId, Duration timeout);
-}

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderRepository.java
@@ -1,6 +1,7 @@
 package com.dfdt.delivery.domain.order.domain.repository;
 
 import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.payment.domain.entity.Payment;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -9,4 +10,5 @@ public interface OrderRepository {
     Order save(Order order);
     Optional<Order> findById(UUID orderId);
     Optional<Order> findByIdWithLock(UUID orderId);
+    Optional<Payment> findPaymentOrderId(UUID orderId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/listener/OrderRedisKeyExpirationListener.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/listener/OrderRedisKeyExpirationListener.java
@@ -1,0 +1,53 @@
+package com.dfdt.delivery.domain.order.infrastructure.listener;
+
+import com.dfdt.delivery.domain.order.domain.enums.OrderRedisPrefix;
+import com.dfdt.delivery.domain.order.domain.event.OrderEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@Slf4j
+public class OrderRedisKeyExpirationListener extends KeyExpirationEventMessageListener {
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    public OrderRedisKeyExpirationListener
+            (RedisMessageListenerContainer listenerContainer,
+             ApplicationEventPublisher applicationEventPublisher) {
+        super(listenerContainer);
+        this.applicationEventPublisher = applicationEventPublisher;
+    }
+
+    /**
+     * Redis 만료 이벤트 발생할 때 실행되는 콜백 함수
+     *
+     * @param message redis key
+     * @param pattern __keyevent@*__:expired
+     */
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        String expiredKey = message.toString();
+        // 키 종류 확인
+        OrderRedisPrefix prefix = OrderRedisPrefix.fromKey(expiredKey);
+        if (prefix == null) return;
+
+        // 주문 아이디 추출
+        UUID orderId = prefix.parseId(expiredKey);
+        log.info("Expired key: {}", expiredKey);
+
+        // 각 상황에 맞는 이벤트 발행
+        switch (prefix) {
+            case ORDER_PENDING -> {
+                applicationEventPublisher.publishEvent(new OrderEvent.PaymentTimeout(orderId));
+            }
+            case OWNER_CONFIRM -> {
+                applicationEventPublisher.publishEvent(new OrderEvent.AcceptanceTimeout(orderId));
+            }
+        }
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/redis/OrderRedisService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/redis/OrderRedisService.java
@@ -1,0 +1,11 @@
+package com.dfdt.delivery.domain.order.infrastructure.persistence.redis;
+
+
+import java.time.Duration;
+import java.util.UUID;
+
+public interface OrderRedisService {
+    void setPaymentTimeout(UUID orderId);
+    void setAcceptTimeout(UUID orderId);
+    void cancelTimeOut(UUID orderId);
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/redis/OrderRedisService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/redis/OrderRedisService.java
@@ -1,7 +1,6 @@
 package com.dfdt.delivery.domain.order.infrastructure.persistence.redis;
 
 
-import java.time.Duration;
 import java.util.UUID;
 
 public interface OrderRedisService {

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/redis/OrderRedisServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/redis/OrderRedisServiceImpl.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.UUID;
 

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/redis/OrderRedisServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/redis/OrderRedisServiceImpl.java
@@ -1,0 +1,46 @@
+package com.dfdt.delivery.domain.order.infrastructure.persistence.redis;
+
+import com.dfdt.delivery.domain.order.domain.enums.OrderRedisPrefix;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class OrderRedisServiceImpl implements OrderRedisService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    // TTL 설정
+    @Override
+    public void setPaymentTimeout(UUID orderId) {
+        String redisKey = OrderRedisPrefix.ORDER_PENDING.generateKey(orderId);
+        redisTemplate.opsForValue().set(
+                redisKey,
+                "waiting",
+                OrderRedisPrefix.ORDER_PENDING.getTtl()
+        );
+    }
+    @Override
+    public void setAcceptTimeout(UUID orderId) {
+        String redisKey = OrderRedisPrefix.OWNER_CONFIRM.generateKey(orderId);
+        redisTemplate.opsForValue().set(
+                redisKey,
+                "waiting",
+                OrderRedisPrefix.OWNER_CONFIRM.getTtl()
+        );
+    }
+    @Override
+    // 키 삭제하기
+    public void cancelTimeOut(UUID orderId) {
+        Arrays.stream(OrderRedisPrefix.values())
+                .forEach(prefix -> removeKey(prefix, orderId));
+    }
+    private void removeKey(OrderRedisPrefix prefix, Object id) {
+        String key = prefix.generateKey(id);
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/redis/RedisConfig.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/redis/RedisConfig.java
@@ -1,4 +1,0 @@
-package com.dfdt.delivery.domain.order.infrastructure.persistence.redis;
-
-public class RedisConfig {
-}

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/JpaOrderRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/JpaOrderRepository.java
@@ -2,6 +2,7 @@ package com.dfdt.delivery.domain.order.infrastructure.persistence.repository;
 
 import com.dfdt.delivery.domain.order.domain.entity.Order;
 import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
+import com.dfdt.delivery.domain.payment.domain.entity.Payment;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -16,4 +17,8 @@ public interface JpaOrderRepository extends JpaRepository<Order, UUID> , OrderRe
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select o from Order o where o.orderId = :orderId")
     Optional<Order> findByIdWithLock(UUID orderId);
+
+    @Override
+    @Query("select p from Payment  p where  p.orderId = :orderId")
+    Optional<Payment> findPaymentOrderId(UUID orderId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
@@ -31,8 +31,6 @@ public class OrderReqDto {
     ){}
     public record UpdateOrder(
             UUID addressId,
-            List<OrderItem> addOrderItems,
-            List<UUID> removeOrderItemIds,
             @Length(max = 255,message = "최대 255자 입니다.")
             String requestMemo
     ){}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #5 

## 📌 작업 내용
Redis TTL(Time To Live) 만료 이벤트를 활용하여 결제 대기 및 사장님 접수 대기 시간을 자동으로 관리하고, 시간 초과 시 주문을 자동 취소 및 환불하는 로직을 구현했습니다.

## ✅ 주요 변경 사항
- **주문 생성 후 결제 생성** : 주문 생성 후 바로 결제 도메인의 서비스 로직을 불러오기 위해 Req, Service 로직을 변경하였습니다.
- **Redis 만료 이벤트 리스너 도입**: RedisConfig에 이벤트 리스너를 등록하고 `OrderRedisKeyExpirationListener`를 통해 Redis 키 삭제 시점을 실시간 감지하였습니다.
- **Spring Event 기반 도메인 로직 분리**: 인프라(Redis)와 비즈니스 로직(Order) 간의 결합도를 낮추기 위해 `OrderEvent` 발행 및 구독 구조 채택
- **주문 상태(OrderStatus) 고도화**: `ordinal()` 기반의 상태 관리 및 한글 설명(`description`) 추가
- **자동 취소 및 환불 연동**: 주문 생성 후 10분 이내 결제 하지 않으면 주문 거절, 결제 생성 후 10분 이내 가게 미수락 시 주문 & 결제 자동 거절 및 환불

## ✅ 참고 사항
@dnjswns98 결제 승인 완료 시 OrderExpirationService의 completePayment를 호출해주세요!
또한 가게 미수락 시 Payment 서비스의 취소 함수를 부르도록 설정하였습니다!

## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인 
- [x] 주요 시나리오 동작 확인
- [x] 예외 케이스 확인 (해당 시)

### 확인 방법
1. **결제 대기 만료**: 주문 생성 후 10분간 방치 시 Redis `order:pending:{id}` 키 삭제와 함께 DB 상태가 `REJECTED`로 변경되는지 확인
2. **사장님 접수 만료**: 결제 완료 후 10분간 사장님이 수락하지 않을 시 `REJECTED` 변경 및 환불 API 호출 확인
3. **정상 흐름**: 결제 완료 또는 사장님 수락 시 Redis에 생성된 TTL 키가 `cancelTimeOut`으로 즉시 삭제되는지 확인

## ⚠️ 영향 범위 (해당 시 체크)
- [ ] API 스펙 변경
- [x] DB 스키마 변경 (OrderStatus 이력 테이블 추가 및 상태값 변경)
- [x] 응답값/에러코드 변경
- [x] 환경설정 변경 (Redis Config 내 MessageListenerContainer 설정 추가)
- [ ] 문서(Swagger/README) 수정

## 👀 리뷰 포인트
- **RedisConfig**: `notify-keyspace-events Ex` 설정이 필요한 부분을 `RedisConfig`나 인프라 문서에 명시할지 의견 부탁드립니다.
- **OrderStatus**: 현재 `ordinal()` 기반으로 상태 전후를 비교하고 있는데, 추후 상태가 추가될 경우를 대비해 `step` 필드 도입 시점에 대해 논의하고 싶습니다.
- **Transactional**: 이벤트 핸들러(`OrderExpirationService`) 내부의 트랜잭션 전파 범위가 적절한지 봐주세요.