### PR TITLE
[Feat] Category 관련 Service, Repository 테스트 코드 구현 

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/category/application/service/CategoryCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/category/application/service/CategoryCommandServiceImpl.java
@@ -5,8 +5,6 @@ import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
 import com.dfdt.delivery.domain.category.application.service.command.CategoryCommandService;
 import com.dfdt.delivery.domain.category.domain.entity.Category;
 import com.dfdt.delivery.domain.category.domain.enums.CategoryErrorCode;
-import com.dfdt.delivery.domain.category.domain.repository.CategoryCustomRepository;
-import com.dfdt.delivery.domain.category.domain.repository.CategoryRepository;
 import com.dfdt.delivery.domain.category.domain.repository.JpaCategoryRepository;
 import com.dfdt.delivery.domain.category.presentation.dto.request.CategoryCreateReqDto;
 import com.dfdt.delivery.domain.category.presentation.dto.request.CategoryUpdateReqDto;
@@ -69,7 +67,7 @@ public class CategoryCommandServiceImpl implements CategoryCommandService {
     public void deleteCategory(UUID categoryId, CustomUserDetails userDetails) {
         Category category = checkExistCategory(categoryId);
 
-        if (category.getSoftDeleteAudit().isDeleted()) {
+        if (category.getSoftDeleteAudit() != null) {
             throw new BusinessException(CategoryErrorCode.ALREADY_DELETED);     // 삭제된 카테고리인지 확인
         }
         if (storeRepository.existsByCategoryIdAndNotDeleted(category.getCategoryId())) {

--- a/src/main/java/com/dfdt/delivery/domain/category/application/service/CategoryQueryServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/category/application/service/CategoryQueryServiceImpl.java
@@ -1,46 +1,36 @@
 package com.dfdt.delivery.domain.category.application.service;
 
 import com.dfdt.delivery.common.exception.BusinessException;
-import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
 import com.dfdt.delivery.domain.category.application.service.query.CategoryQueryService;
 import com.dfdt.delivery.domain.category.domain.entity.Category;
 import com.dfdt.delivery.domain.category.domain.enums.CategoryErrorCode;
 import com.dfdt.delivery.domain.category.domain.repository.CategoryCustomRepository;
-import com.dfdt.delivery.domain.category.domain.repository.CategoryRepository;
 import com.dfdt.delivery.domain.category.domain.repository.JpaCategoryRepository;
-import com.dfdt.delivery.domain.category.presentation.dto.request.CategoryCreateReqDto;
-import com.dfdt.delivery.domain.category.presentation.dto.request.CategoryUpdateReqDto;
 import com.dfdt.delivery.domain.category.presentation.dto.response.CategoryAdminResDto;
 import com.dfdt.delivery.domain.category.presentation.dto.response.CategoryResDto;
-import com.dfdt.delivery.domain.category.presentation.dto.response.CategoryUpdateResDto;
-import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class CategoryQueryServiceImpl implements CategoryQueryService {
 
     private final JpaCategoryRepository categoryRepository;
     private final CategoryCustomRepository categoryCustomRepository;
 
-    @Transactional(readOnly = true)
     public CategoryResDto getCategory(UUID categoryId) {
         Category category = checkExistCategory(categoryId);
 
         return CategoryResDto.from(category);
     }
 
-    @Transactional(readOnly = true)
     public List<CategoryResDto> getCategories() {
         List<Category> categories = categoryRepository.findActiveCategoriesOrderBySortOrder();
         if (categories.isEmpty()) {
@@ -52,7 +42,6 @@ public class CategoryQueryServiceImpl implements CategoryQueryService {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
     public Page<CategoryAdminResDto> getCategoriesAdmin(int page, int size, String sortBy, Boolean isAsc, String name, boolean isDeleted) {
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
         Sort sort = Sort.by(direction, sortBy);

--- a/src/test/java/com/dfdt/delivery/domain/category/application/fixture/CategoryFixture.java
+++ b/src/test/java/com/dfdt/delivery/domain/category/application/fixture/CategoryFixture.java
@@ -1,0 +1,33 @@
+package com.dfdt.delivery.domain.category.application.fixture;
+
+import com.dfdt.delivery.common.infrastructure.persistence.embedded.CreateAudit;
+import com.dfdt.delivery.common.infrastructure.persistence.embedded.SoftDeleteAudit;
+import com.dfdt.delivery.domain.category.domain.entity.Category;
+
+import java.util.UUID;
+
+public class CategoryFixture {
+
+    public static Category createCategory() {
+        return Category.builder()
+                .categoryId(UUID.randomUUID())
+                .name("테스트 카테고리")
+                .description("카테고리 설명")
+                .sortOrder(0)
+                .isActive(true)
+                .createAudit(CreateAudit.now("테스트 유저"))
+                .build();
+    }
+
+    public static Category deleteCategory() {
+        return Category.builder()
+                .categoryId(UUID.randomUUID())
+                .name("테스트 카테고리")
+                .description("카테고리 설명")
+                .sortOrder(0)
+                .isActive(true)
+                .createAudit(CreateAudit.now("테스트 유저"))
+                .softDeleteAudit(SoftDeleteAudit.active())
+                .build();
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/category/application/fixture/CategoryFixture.java
+++ b/src/test/java/com/dfdt/delivery/domain/category/application/fixture/CategoryFixture.java
@@ -30,4 +30,14 @@ public class CategoryFixture {
                 .softDeleteAudit(SoftDeleteAudit.active())
                 .build();
     }
+
+    public static Category repoCategory(String name, Integer sortOrder) {
+        return Category.builder()
+                .name(name)
+                .description("카테고리 설명")
+                .sortOrder(sortOrder)
+                .isActive(true)
+                .createAudit(CreateAudit.now("테스트 유저"))
+                .build();
+    }
 }

--- a/src/test/java/com/dfdt/delivery/domain/category/application/fixture/CategoryFixture.java
+++ b/src/test/java/com/dfdt/delivery/domain/category/application/fixture/CategoryFixture.java
@@ -1,7 +1,6 @@
 package com.dfdt.delivery.domain.category.application.fixture;
 
 import com.dfdt.delivery.common.infrastructure.persistence.embedded.CreateAudit;
-import com.dfdt.delivery.common.infrastructure.persistence.embedded.SoftDeleteAudit;
 import com.dfdt.delivery.domain.category.domain.entity.Category;
 
 import java.util.UUID;
@@ -16,18 +15,6 @@ public class CategoryFixture {
                 .sortOrder(0)
                 .isActive(true)
                 .createAudit(CreateAudit.now("테스트 유저"))
-                .build();
-    }
-
-    public static Category deleteCategory() {
-        return Category.builder()
-                .categoryId(UUID.randomUUID())
-                .name("테스트 카테고리")
-                .description("카테고리 설명")
-                .sortOrder(0)
-                .isActive(true)
-                .createAudit(CreateAudit.now("테스트 유저"))
-                .softDeleteAudit(SoftDeleteAudit.active())
                 .build();
     }
 

--- a/src/test/java/com/dfdt/delivery/domain/category/application/fixture/UserFixture.java
+++ b/src/test/java/com/dfdt/delivery/domain/category/application/fixture/UserFixture.java
@@ -1,0 +1,17 @@
+package com.dfdt.delivery.domain.category.application.fixture;
+
+import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+
+public class UserFixture {
+
+    public static User createUser() {
+        return User.builder()
+                .username("tester")
+                .password("password")
+                .role(UserRole.MASTER)
+                .name("testerName")
+                .build();
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/category/application/repository/CategoryCustomRepositoryTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/category/application/repository/CategoryCustomRepositoryTest.java
@@ -1,0 +1,174 @@
+package com.dfdt.delivery.domain.category.application.repository;
+
+import com.dfdt.delivery.domain.category.application.fixture.CategoryFixture;
+import com.dfdt.delivery.domain.category.domain.entity.Category;
+import com.dfdt.delivery.domain.category.domain.repository.CategoryCustomRepository;
+import com.dfdt.delivery.domain.category.domain.repository.CategoryRepository;
+import com.dfdt.delivery.domain.category.infrastructure.persistence.repository.CategoryCustomRepositoryImpl;
+import com.dfdt.delivery.domain.category.presentation.dto.response.CategoryAdminResDto;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(CategoryCustomRepositoryImpl.class)
+public class CategoryCustomRepositoryTest {
+
+    @Autowired
+    private CategoryCustomRepository categoryCustomRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private Category category0;
+    private Category category1;
+    private Category category2;
+
+    @BeforeEach
+    void setUp() {
+        category0 = CategoryFixture.repoCategory("한식", 0);
+        category1 = CategoryFixture.repoCategory("일식", 1);
+        category2 = CategoryFixture.repoCategory("양식", 2);
+
+        em.persist(category0);
+        em.persist(category1);
+        em.persist(category2);
+
+        em.flush();
+    }
+
+    @TestConfiguration
+    static class QuerydslConfig {
+
+        @PersistenceContext
+        private EntityManager em;
+
+        @Bean
+        JPAQueryFactory jpaQueryFactory() {
+            return new JPAQueryFactory(em);
+        }
+    }
+
+    @Test
+    @DisplayName("이름으로 검색")
+    void successSearchByName() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "sortOrder"));
+
+        // when
+        Page<CategoryAdminResDto> result = categoryCustomRepository.searchCategoriesAdmin(pageable, "한식", false);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().getFirst().getName()).isEqualTo("한식");
+    }
+
+    @Test
+    @DisplayName("삭제되지 않은 카테고리만 조회")
+    void successNotDeletedOnly() {
+        // given
+        category2.delete("tester");
+        em.flush();
+        em.clear();
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "sortOrder"));
+
+        // when
+        Page<CategoryAdminResDto> result = categoryCustomRepository.searchCategoriesAdmin(pageable, null, false);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(2);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent())
+                .extracting(CategoryAdminResDto::getName)
+                .containsExactly("한식", "일식");
+    }
+
+    @Test
+    @DisplayName("삭제된 카테고리만 조회")
+    void successDeletedOnly() {
+        // given
+        category2.delete("tester");
+        em.flush();
+        em.clear();
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "sortOrder"));
+
+        // when
+        Page<CategoryAdminResDto> result = categoryCustomRepository.searchCategoriesAdmin(pageable, null, true);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().getFirst().getName()).isEqualTo("양식");
+    }
+
+    @Test
+    @DisplayName("삭제 여부와 이름 조건을 함께 적용")
+    void successNameAndDeletedCondition() {
+        // given
+        category2.delete("tester");
+        em.flush();
+        em.clear();
+
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "sortOrder"));
+
+        // when
+        Page<CategoryAdminResDto> result = categoryCustomRepository.searchCategoriesAdmin(pageable, "양식", true);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().getFirst().getName()).isEqualTo("양식");
+    }
+
+    @Test
+    @DisplayName("페이징 적용")
+    void successPaging() {
+        // given
+        Pageable pageable = PageRequest.of(0, 2, Sort.by(Sort.Direction.ASC, "sortOrder"));
+
+        // when
+        Page<CategoryAdminResDto> result = categoryCustomRepository.searchCategoriesAdmin(pageable, null, false);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.hasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("정렬 적용")
+    void successSorting() {
+        // given
+        Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "sortOrder"));
+
+        // when
+        Page<CategoryAdminResDto> result = categoryCustomRepository.searchCategoriesAdmin(pageable, null, false);
+
+        // then
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getContent().get(0).getSortOrder()).isEqualTo(2);
+        assertThat(result.getContent().get(1).getSortOrder()).isEqualTo(1);
+        assertThat(result.getContent().get(2).getSortOrder()).isEqualTo(0);
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/category/application/repository/CategoryRepositoryTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/category/application/repository/CategoryRepositoryTest.java
@@ -1,0 +1,315 @@
+package com.dfdt.delivery.domain.category.application.repository;
+
+import com.dfdt.delivery.domain.category.application.fixture.CategoryFixture;
+import com.dfdt.delivery.domain.category.domain.entity.Category;
+import com.dfdt.delivery.domain.category.domain.repository.CategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DataJpaTest
+class CategoryRepositoryTest {
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private TestEntityManager em;
+
+    private Category category0;
+    private Category category1;
+    private Category category2;
+
+    @BeforeEach
+    void setUp() {
+        category0 = CategoryFixture.repoCategory("한식", 0);
+        category1 = CategoryFixture.repoCategory("일식", 1);
+        category2 = CategoryFixture.repoCategory("양식", 2);
+
+        em.persist(category0);
+        em.persist(category1);
+        em.persist(category2);
+
+        em.flush();
+    }
+
+    @Nested
+    @DisplayName("existsByNameAndCategoryIdNot")
+    class ExistsByNameAndCategoryIdNotTest {
+
+        @Test
+        @DisplayName("같은 이름의 다른 카테고리가 있으면 true를 반환")
+        void success_true() {
+            // when
+            boolean result = categoryRepository.existsByNameAndCategoryIdNot("한식", category1.getCategoryId());
+
+            // then
+            assertTrue(result);
+        }
+
+        @Test
+        @DisplayName("같은 이름의 다른 카테고리가 없으면 false를 반환")
+        void success_false() {
+            // when
+            boolean result = categoryRepository.existsByNameAndCategoryIdNot("한식", category0.getCategoryId());
+
+            // then
+            assertFalse(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("findMaxSortOrder")
+    class FindMaxSortOrderTest {
+
+        @Test
+        @DisplayName("삭제되지 않은 카테고리의 최대 sortOrder를 조회")
+        void success() {
+            // when
+            Optional<Integer> result = categoryRepository.findMaxSortOrder();
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("삭제된 카테고리는 최대 sortOrder 계산에서 제외")
+        void ignoreDeletedCategory() {
+            // given
+            category2.delete("tester");
+            em.flush();
+
+            // when
+            Optional<Integer> result = categoryRepository.findMaxSortOrder();
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("findActiveCategoriesOrderBySortOrder")
+    class FindActiveCategoriesOrderBySortOrderTest {
+
+        @Test
+        @DisplayName("삭제되지 않은 카테고리를 sortOrder 오름차순으로 조회")
+        void success() {
+            // when
+            List<Category> result = categoryRepository.findActiveCategoriesOrderBySortOrder();
+
+            // then
+            assertThat(result).hasSize(3);
+            assertThat(result.get(0).getSortOrder()).isEqualTo(0);
+            assertThat(result.get(1).getSortOrder()).isEqualTo(1);
+            assertThat(result.get(2).getSortOrder()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("삭제된 카테고리는 조회에서 제외")
+        void excludeDeleted() {
+            // given
+            category0.delete("tester");
+            em.flush();
+            em.clear();
+
+            // when
+            List<Category> result = categoryRepository.findActiveCategoriesOrderBySortOrder();
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result).extracting(Category::getName).containsExactly("일식", "양식");
+        }
+    }
+
+    @Nested
+    @DisplayName("findActiveCategoryById")
+    class FindActiveCategoryByIdTest {
+
+        @Test
+        @DisplayName("삭제되지 않은 카테고리를 ID로 조회")
+        void success() {
+            // when
+            Optional<Category> result = categoryRepository.findActiveCategoryById(category0.getCategoryId());
+
+            // then
+            assertThat(result).isPresent();
+            assertThat(result.get().getName()).isEqualTo("한식");
+        }
+
+        @Test
+        @DisplayName("삭제된 카테고리는 조회 X")
+        void deletedCategoryNotFound() {
+            // given
+            category0.delete("tester");
+            em.flush();
+            em.clear();
+
+            // when
+            Optional<Category> result = categoryRepository.findActiveCategoryById(category0.getCategoryId());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("shiftSortOrdersUp")
+    class ShiftSortOrdersUpTest {
+
+        @Test
+        @DisplayName("지정 범위의 sortOrder를 1씩 증가")
+        void success() {
+            // when
+            categoryRepository.shiftSortOrdersUp(0, 1);
+            em.flush();
+            em.clear();
+
+            // then
+            Category result0 = categoryRepository.findActiveCategoryById(category0.getCategoryId()).orElseThrow();
+            Category result1 = categoryRepository.findActiveCategoryById(category1.getCategoryId()).orElseThrow();
+
+            assertThat(result0.getSortOrder()).isEqualTo(1);
+            assertThat(result1.getSortOrder()).isEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("삭제된 카테고리는 증가 대상에서 제외")
+        void ignoreDeleted() {
+            // given
+            category1.delete("tester");
+            em.flush();
+
+            // when
+            categoryRepository.shiftSortOrdersUp(0, 1);
+            em.flush();
+            em.clear();
+
+            // then
+            Category result0 = categoryRepository.findActiveCategoryById(category0.getCategoryId()).orElseThrow();
+            Category result1 = em.find(Category.class, category1.getCategoryId());
+            Category result2 = categoryRepository.findActiveCategoryById(category2.getCategoryId()).orElseThrow();
+
+            assertThat(result0.getSortOrder()).isEqualTo(1);
+            assertThat(result1.getSortOrder()).isEqualTo(1);
+            assertThat(result2.getSortOrder()).isEqualTo(2);
+        }
+    }
+
+    @Nested
+    @DisplayName("shiftSortOrdersDown")
+    class ShiftSortOrdersDownTest {
+
+        @Test
+        @DisplayName("지정 범위의 sortOrder를 1씩 감소")
+        void success() {
+            // when
+            categoryRepository.shiftSortOrdersDown(1, 2);
+            em.flush();
+            em.clear();
+
+            // then
+            Category result0 = categoryRepository.findActiveCategoryById(category0.getCategoryId()).orElseThrow();
+            Category result1 = categoryRepository.findActiveCategoryById(category1.getCategoryId()).orElseThrow();
+            Category result2 = categoryRepository.findActiveCategoryById(category2.getCategoryId()).orElseThrow();
+
+            assertThat(result0.getSortOrder()).isEqualTo(0);
+            assertThat(result1.getSortOrder()).isEqualTo(0);
+            assertThat(result2.getSortOrder()).isEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("삭제된 카테고리는 감소 대상에서 제외")
+        void ignoreDeleted() {
+            // given
+            category1.delete("tester");
+            em.flush();
+
+            // when
+            categoryRepository.shiftSortOrdersDown(1, 2);
+            em.flush();
+            em.clear();
+
+            // then
+            Category result0 = categoryRepository.findActiveCategoryById(category0.getCategoryId()).orElseThrow();
+            Category result1 = em.find(Category.class, category1.getCategoryId());
+            Category result2 = categoryRepository.findActiveCategoryById(category2.getCategoryId()).orElseThrow();
+
+            assertThat(result0.getSortOrder()).isEqualTo(0);
+            assertThat(result1.getSortOrder()).isEqualTo(1);
+            assertThat(result2.getSortOrder()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("decrementSortOrdersAfter")
+    class DecrementSortOrdersAfterTest {
+
+        @Test
+        @DisplayName("deletedOrder보다 큰 sortOrder를 1씩 감소")
+        void success() {
+            // when
+            categoryRepository.decrementSortOrdersAfter(0);
+            em.flush();
+            em.clear();
+
+            // then
+            Category result1 = categoryRepository.findActiveCategoryById(category1.getCategoryId()).orElseThrow();
+            Category result2 = categoryRepository.findActiveCategoryById(category2.getCategoryId()).orElseThrow();
+
+            assertThat(result1.getSortOrder()).isEqualTo(0);
+            assertThat(result2.getSortOrder()).isEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("existsByNameAndDeletedAtIsNull")
+    class ExistsByNameAndDeletedAtIsNullTest {
+
+        @Test
+        @DisplayName("삭제되지 않은 같은 이름의 카테고리가 있으면 true를 반환")
+        void successTrue() {
+            // when
+            boolean result = categoryRepository.existsByNameAndDeletedAtIsNull("한식");
+
+            // then
+            assertTrue(result);
+        }
+
+        @Test
+        @DisplayName("삭제된 카테고리만 있으면 false를 반환")
+        void successFalseWhenDeleted() {
+            // given
+            category1.delete("tester");
+            em.flush();
+
+            // when
+            boolean result = categoryRepository.existsByNameAndDeletedAtIsNull("한식1");
+
+            // then
+            assertFalse(result);
+        }
+
+        @Test
+        @DisplayName("같은 이름의 카테고리가 없으면 false를 반환한다")
+        void successFalse() {
+            // when
+            boolean result = categoryRepository.existsByNameAndDeletedAtIsNull("분식");
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/category/application/service/CategoryCommandServiceImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/category/application/service/CategoryCommandServiceImplTest.java
@@ -1,0 +1,336 @@
+package com.dfdt.delivery.domain.category.application.service;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.common.infrastructure.persistence.embedded.CreateAudit;
+import com.dfdt.delivery.common.infrastructure.persistence.embedded.SoftDeleteAudit;
+import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
+import com.dfdt.delivery.domain.category.application.fixture.CategoryFixture;
+import com.dfdt.delivery.domain.category.application.fixture.UserFixture;
+import com.dfdt.delivery.domain.category.domain.entity.Category;
+import com.dfdt.delivery.domain.category.domain.enums.CategoryErrorCode;
+import com.dfdt.delivery.domain.category.domain.repository.JpaCategoryRepository;
+import com.dfdt.delivery.domain.category.presentation.dto.request.CategoryCreateReqDto;
+import com.dfdt.delivery.domain.category.presentation.dto.request.CategoryUpdateReqDto;
+import com.dfdt.delivery.domain.category.presentation.dto.response.CategoryResDto;
+import com.dfdt.delivery.domain.category.presentation.dto.response.CategoryUpdateResDto;
+import com.dfdt.delivery.domain.store.domain.repository.JpaStoreRepository;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StoreCommandService 테스트")
+public class CategoryCommandServiceImplTest {
+
+    @InjectMocks
+    private CategoryCommandServiceImpl categoryService;
+
+    @Mock
+    private JpaCategoryRepository categoryRepository;
+
+    @Mock
+    private JpaStoreRepository storeRepository;
+
+    @Mock
+    private User user;
+
+    @Mock
+    private CustomUserDetails userDetails;
+
+    @Mock
+    private Category category;
+
+    @BeforeEach
+    void setUp() {
+        user = UserFixture.createUser();
+        category = CategoryFixture.createCategory();
+    }
+
+    @Nested
+    @DisplayName("카테고리 생성")
+    class CreateCategoryTest {
+
+        @Test
+        @DisplayName("성공: 중복이 아니면 maxSortOrder+1로 생성 후 저장하고 DTO를 반환한다")
+        void success() {
+            // given
+            CategoryCreateReqDto request = new CategoryCreateReqDto();
+            request.setName("한식");
+
+            when(userDetails.getUsername()).thenReturn(user.getUsername());
+            when(categoryRepository.existsByNameAndDeletedAtIsNull("한식")).thenReturn(false);
+            when(categoryRepository.findMaxSortOrder()).thenReturn(Optional.of(0));
+            when(categoryRepository.save(any(Category.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+            // when
+            CategoryResDto result = categoryService.createCategory(request, userDetails);
+
+            // then
+            assertNotNull(result);
+            assertEquals(1, result.getSortOrder());
+            verify(categoryRepository).save(any(Category.class));
+        }
+
+        @Test
+        @DisplayName("실패: 카테고리명이 이미 존재하면 ALREADY_EXIST 예외가 발생한다")
+        void fail_alreadyExist() {
+            // given
+            CategoryCreateReqDto request = new CategoryCreateReqDto();
+            request.setName("한식");
+
+            when(categoryRepository.existsByNameAndDeletedAtIsNull("한식")).thenReturn(true);
+
+            // when & then
+            BusinessException ex = assertThrows(BusinessException.class, () -> categoryService.createCategory(request, userDetails));
+
+            assertEquals(CategoryErrorCode.ALREADY_EXIST, ex.getErrorCode());
+            verify(categoryRepository, never()).findMaxSortOrder();
+            verify(categoryRepository, never()).save(any(Category.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 수정")
+    class UpdateCategoryTest {
+        @Test
+        @DisplayName("성공: sortOrder를 아래(0 -> 1)로 이동하면 shiftSortOrdersDown이 호출된다")
+        void successOrdersDown() {
+            // given
+            UUID categoryId = category.getCategoryId();
+            CategoryUpdateReqDto request = new CategoryUpdateReqDto();
+            request.setName("테스트 카테고리2");
+            request.setSortOrder(1);
+            request.setDescription("카테고리 설명2");
+
+            when(categoryRepository.findActiveCategoryById(categoryId)).thenReturn(Optional.of(category));
+            when(categoryRepository.existsByNameAndCategoryIdNot(anyString(), eq(categoryId))).thenReturn(false);
+            when(userDetails.getUsername()).thenReturn(user.getUsername());
+
+            // when
+            CategoryUpdateResDto result = categoryService.updateCategory(categoryId, request, userDetails);
+
+            // then
+            assertNotNull(result);
+            assertEquals(1, result.getSortOrder());
+            verify(categoryRepository, never()).shiftSortOrdersUp(anyInt(), anyInt());
+            verify(categoryRepository, times(1)).shiftSortOrdersDown(anyInt(), anyInt());
+        }
+
+        @Test
+        @DisplayName("성공: sortOrder를 위(1 -> 0)로 이동하면 shiftSortOrdersUp이 호출된다")
+        void successOrdersUp() {
+            // given
+            Category category = Category.builder()
+                    .categoryId(UUID.randomUUID())
+                    .name("테스트 카테고리")
+                    .description("카테고리 설명")
+                    .sortOrder(1)
+                    .isActive(true)
+                    .createAudit(CreateAudit.now("테스트 유저"))
+                    .build();;
+            UUID categoryId = category.getCategoryId();
+
+            CategoryUpdateReqDto request = new CategoryUpdateReqDto();
+            request.setName("테스트 카테고리2");
+            request.setSortOrder(0);
+            request.setDescription("카테고리 설명2");
+
+            when(categoryRepository.findActiveCategoryById(categoryId)).thenReturn(Optional.of(category));
+            when(categoryRepository.existsByNameAndCategoryIdNot(anyString(), eq(categoryId))).thenReturn(false);
+            when(userDetails.getUsername()).thenReturn(user.getUsername());
+
+            // when
+            CategoryUpdateResDto result = categoryService.updateCategory(categoryId, request, userDetails);
+
+            // then
+            assertNotNull(result);
+            assertEquals(0, result.getSortOrder());
+            verify(categoryRepository, never()).shiftSortOrdersDown(anyInt(), anyInt());
+            verify(categoryRepository, times(1)).shiftSortOrdersUp(anyInt(), anyInt());
+        }
+
+        @Test
+        @DisplayName("실패: 수정 시 중복 카테고리명이면 ALREADY_EXIST 예외 발생")
+        void failAlreadyExistName() {
+            // given
+            UUID categoryId = category.getCategoryId();
+            Category mockCategory = mock(Category.class);
+            CategoryUpdateReqDto request = mock(CategoryUpdateReqDto.class);
+
+            when(categoryRepository.findActiveCategoryById(categoryId)).thenReturn(Optional.of(mockCategory));
+            when(request.getName()).thenReturn("중복");
+            when(categoryRepository.existsByNameAndCategoryIdNot("중복", categoryId)).thenReturn(true);
+
+            // when & then
+            BusinessException ex = assertThrows(BusinessException.class, () -> categoryService.updateCategory(categoryId, request, userDetails));
+
+            assertEquals(CategoryErrorCode.ALREADY_EXIST, ex.getErrorCode());
+            verify(mockCategory, never()).update(any(), anyString());
+        }
+
+        @Test
+        @DisplayName("실패: 삭제된 카테고리는 수정할 수 없다(NOT_MODIFIED)")
+        void failDeletedCategoryNotModified() {
+            // given
+            UUID categoryId = category.getCategoryId();
+            Category category = mock(Category.class);
+            CategoryUpdateReqDto request = mock(CategoryUpdateReqDto.class);
+
+            when(categoryRepository.findActiveCategoryById(categoryId)).thenReturn(Optional.of(category));
+            when(request.getName()).thenReturn("한식");
+            when(categoryRepository.existsByNameAndCategoryIdNot("한식", categoryId)).thenReturn(false);
+
+            when(category.getSoftDeleteAudit()).thenReturn(mock(SoftDeleteAudit.class));
+
+            // when & then
+            BusinessException ex = assertThrows(BusinessException.class, () -> categoryService.updateCategory(categoryId, request, userDetails));
+
+            assertEquals(CategoryErrorCode.NOT_MODIFIED, ex.getErrorCode());
+            verify(category, never()).update(any(), anyString());
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 카테고리면 NOT_FOUND_CATEGORY 예외 발생")
+        void fail_notFound() {
+            // given
+            UUID categoryId = category.getCategoryId();
+            CategoryUpdateReqDto request = mock(CategoryUpdateReqDto.class);
+
+            when(categoryRepository.findActiveCategoryById(categoryId)).thenReturn(Optional.empty());
+
+            // when & then
+            BusinessException ex = assertThrows(BusinessException.class, () -> categoryService.updateCategory(categoryId, request, userDetails));
+
+            assertEquals(CategoryErrorCode.NOT_FOUND_CATEGORY, ex.getErrorCode());
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 삭제")
+    class DeleteCategoryTest {
+        @Test
+        @DisplayName("성공: 사용 중인 가게가 없으면 카테고리를 삭제하고 이후 sortOrder를 감소시킨다")
+        void success() {
+            // given
+            Category category = CategoryFixture.deleteCategory();
+            UUID categoryId = category.getCategoryId();
+
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+            when(storeRepository.existsByCategoryIdAndNotDeleted(categoryId)).thenReturn(false);
+            when(userDetails.getUsername()).thenReturn(user.getUsername());
+
+            // when
+            categoryService.deleteCategory(categoryId, userDetails);
+
+            // then
+            verify(categoryRepository, times(1)).decrementSortOrdersAfter(category.getSortOrder());
+        }
+
+        @Test
+        @DisplayName("실패: 이미 삭제된 카테고리이면 예외가 발생한다")
+        void failAlreadyDeleted() {
+            // given
+            UUID categoryId = category.getCategoryId();
+
+            category.delete(userDetails.getUsername());
+
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+
+            // when & then
+            BusinessException exception = assertThrows(BusinessException.class, () -> categoryService.deleteCategory(categoryId, userDetails));
+
+            assertEquals(CategoryErrorCode.ALREADY_DELETED, exception.getErrorCode());
+            verify(storeRepository, never()).existsByCategoryIdAndNotDeleted(any());
+            verify(categoryRepository, never()).decrementSortOrdersAfter(anyInt());
+        }
+
+        @Test
+        @DisplayName("실패: 해당 카테고리를 사용 중인 가게가 있으면 예외가 발생한다")
+        void failCategoryBeUsed() {
+            // given
+            Category category = CategoryFixture.deleteCategory();
+            UUID categoryId = category.getCategoryId();
+
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+            when(storeRepository.existsByCategoryIdAndNotDeleted(categoryId)).thenReturn(true);
+
+            // when & then
+            BusinessException exception = assertThrows(BusinessException.class, () -> categoryService.deleteCategory(categoryId, userDetails));
+
+            assertEquals(CategoryErrorCode.CATEGORY_BE_USED, exception.getErrorCode());
+            verify(categoryRepository, never()).decrementSortOrdersAfter(anyInt());
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 복구")
+    class RestoreCategoryTest {
+        @Test
+        @DisplayName("성공: 삭제된 카테고리를 마지막 sortOrder + 1로 복구한다")
+        void success() {
+            // given
+            UUID categoryId = category.getCategoryId();
+
+            category.delete(userDetails.getUsername());
+
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+            when(categoryRepository.existsByNameAndDeletedAtIsNull(category.getName())).thenReturn(false);
+            when(categoryRepository.findMaxSortOrder()).thenReturn(Optional.of(0));
+            when(userDetails.getUsername()).thenReturn(user.getUsername());
+
+            // when
+            categoryService.restoreCategory(categoryId, userDetails);
+
+            // then
+            assertEquals(1, category.getSortOrder());
+            verify(categoryRepository, times(1)).findMaxSortOrder();
+        }
+
+        @Test
+        @DisplayName("실패: 삭제되지 않은 카테고리이면 예외가 발생한다")
+        void failNotDeleted() {
+            // given
+            UUID categoryId = category.getCategoryId();
+
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+
+            // when & then
+            BusinessException exception = assertThrows(BusinessException.class, () -> categoryService.restoreCategory(categoryId, userDetails));
+
+            assertEquals(CategoryErrorCode.NOT_DELETED, exception.getErrorCode());
+            verify(categoryRepository, never()).findMaxSortOrder();
+        }
+
+        @Test
+        @DisplayName("실패: 복구하려는 카테고리 이름이 이미 존재하면 예외가 발생한다")
+        void failDuplicatedName() {
+            // given
+            UUID categoryId = category.getCategoryId();
+
+            category.delete(userDetails.getUsername());
+
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+            when(categoryRepository.existsByNameAndDeletedAtIsNull(category.getName())).thenReturn(true);
+
+            // when & then
+            BusinessException exception = assertThrows(BusinessException.class, () -> categoryService.restoreCategory(categoryId, userDetails));
+
+            assertEquals(CategoryErrorCode.ALREADY_EXIST, exception.getErrorCode());
+            verify(categoryRepository, never()).findMaxSortOrder();
+        }
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/category/application/service/CategoryCommandServiceImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/category/application/service/CategoryCommandServiceImplTest.java
@@ -65,7 +65,7 @@ public class CategoryCommandServiceImplTest {
     class CreateCategoryTest {
 
         @Test
-        @DisplayName("성공: 중복이 아니면 maxSortOrder+1로 생성 후 저장하고 DTO를 반환한다")
+        @DisplayName("성공: 중복이 아니면 maxSortOrder+1로 생성 후 저장하고 DTO를 반환")
         void success() {
             // given
             CategoryCreateReqDto request = new CategoryCreateReqDto();
@@ -86,7 +86,7 @@ public class CategoryCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("실패: 카테고리명이 이미 존재하면 ALREADY_EXIST 예외가 발생한다")
+        @DisplayName("실패: 카테고리명이 이미 존재하면 ALREADY_EXIST 예외가 발생")
         void fail_alreadyExist() {
             // given
             CategoryCreateReqDto request = new CategoryCreateReqDto();
@@ -107,7 +107,7 @@ public class CategoryCommandServiceImplTest {
     @DisplayName("카테고리 수정")
     class UpdateCategoryTest {
         @Test
-        @DisplayName("성공: sortOrder를 아래(0 -> 1)로 이동하면 shiftSortOrdersDown이 호출된다")
+        @DisplayName("성공: sortOrder를 아래(0 -> 1)로 이동하면 shiftSortOrdersDown이 호출")
         void successOrdersDown() {
             // given
             UUID categoryId = category.getCategoryId();
@@ -131,7 +131,7 @@ public class CategoryCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("성공: sortOrder를 위(1 -> 0)로 이동하면 shiftSortOrdersUp이 호출된다")
+        @DisplayName("성공: sortOrder를 위(1 -> 0)로 이동하면 shiftSortOrdersUp이 호출")
         void successOrdersUp() {
             // given
             Category category = Category.builder()
@@ -223,10 +223,9 @@ public class CategoryCommandServiceImplTest {
     @DisplayName("카테고리 삭제")
     class DeleteCategoryTest {
         @Test
-        @DisplayName("성공: 사용 중인 가게가 없으면 카테고리를 삭제하고 이후 sortOrder를 감소시킨다")
+        @DisplayName("성공: 사용 중인 가게가 없으면 카테고리를 삭제하고 이후 sortOrder를 감소")
         void success() {
             // given
-            Category category = CategoryFixture.deleteCategory();
             UUID categoryId = category.getCategoryId();
 
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
@@ -241,7 +240,7 @@ public class CategoryCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("실패: 이미 삭제된 카테고리이면 예외가 발생한다")
+        @DisplayName("실패: 이미 삭제된 카테고리이면 예외가 발생")
         void failAlreadyDeleted() {
             // given
             UUID categoryId = category.getCategoryId();
@@ -259,10 +258,9 @@ public class CategoryCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("실패: 해당 카테고리를 사용 중인 가게가 있으면 예외가 발생한다")
+        @DisplayName("실패: 해당 카테고리를 사용 중인 가게가 있으면 예외가 발생")
         void failCategoryBeUsed() {
             // given
-            Category category = CategoryFixture.deleteCategory();
             UUID categoryId = category.getCategoryId();
 
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
@@ -280,7 +278,7 @@ public class CategoryCommandServiceImplTest {
     @DisplayName("카테고리 복구")
     class RestoreCategoryTest {
         @Test
-        @DisplayName("성공: 삭제된 카테고리를 마지막 sortOrder + 1로 복구한다")
+        @DisplayName("성공: 삭제된 카테고리를 마지막 sortOrder + 1로 복구")
         void success() {
             // given
             UUID categoryId = category.getCategoryId();
@@ -301,7 +299,7 @@ public class CategoryCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("실패: 삭제되지 않은 카테고리이면 예외가 발생한다")
+        @DisplayName("실패: 삭제되지 않은 카테고리이면 예외가 발생")
         void failNotDeleted() {
             // given
             UUID categoryId = category.getCategoryId();
@@ -316,7 +314,7 @@ public class CategoryCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("실패: 복구하려는 카테고리 이름이 이미 존재하면 예외가 발생한다")
+        @DisplayName("실패: 복구하려는 카테고리 이름이 이미 존재하면 예외가 발생")
         void failDuplicatedName() {
             // given
             UUID categoryId = category.getCategoryId();

--- a/src/test/java/com/dfdt/delivery/domain/category/application/service/CategoryQueryServiceImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/category/application/service/CategoryQueryServiceImplTest.java
@@ -1,0 +1,189 @@
+package com.dfdt.delivery.domain.category.application.service;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.category.application.fixture.CategoryFixture;
+import com.dfdt.delivery.domain.category.domain.entity.Category;
+import com.dfdt.delivery.domain.category.domain.enums.CategoryErrorCode;
+import com.dfdt.delivery.domain.category.domain.repository.CategoryCustomRepository;
+import com.dfdt.delivery.domain.category.domain.repository.JpaCategoryRepository;
+import com.dfdt.delivery.domain.category.presentation.dto.response.CategoryAdminResDto;
+import com.dfdt.delivery.domain.category.presentation.dto.response.CategoryResDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("StoreQueryService 테스트")
+public class CategoryQueryServiceImplTest {
+
+    @InjectMocks
+    private CategoryQueryServiceImpl categoryService;
+
+    @Mock
+    private JpaCategoryRepository categoryRepository;
+
+    @Mock
+    private CategoryCustomRepository categoryCustomRepository;
+
+    @Mock
+    private Category category;
+
+    @BeforeEach
+    void setUp() {
+        category = CategoryFixture.createCategory();
+    }
+
+    @Nested
+    @DisplayName("카테고리 단일 조회")
+    class GetCategoryTest {
+        @Test
+        @DisplayName("성공: 카테고리 조회 시 DTO로 반환한다")
+        void success() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+
+            CategoryResDto resDto = mock(CategoryResDto.class);
+
+            try (MockedStatic<CategoryResDto> mocked = mockStatic(CategoryResDto.class)) {
+                mocked.when(() -> CategoryResDto.from(category)).thenReturn(resDto);
+
+                // when
+                CategoryResDto result = categoryService.getCategory(categoryId);
+
+                // then
+                assertNotNull(result);
+                assertSame(resDto, result);
+
+                verify(categoryRepository, times(1)).findById(categoryId);
+                mocked.verify(() -> CategoryResDto.from(category), times(1));
+            }
+        }
+
+        @Test
+        @DisplayName("실패: 카테고리가 없으면 NOT_FOUND_CATEGORY 예외가 발생한다")
+        void failNotFound() {
+            // given
+            UUID categoryId = UUID.randomUUID();
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.empty());
+
+            // when & then
+            BusinessException ex = assertThrows(BusinessException.class, () -> categoryService.getCategory(categoryId));
+
+            assertEquals(CategoryErrorCode.NOT_FOUND_CATEGORY, ex.getErrorCode());
+            verify(categoryRepository, times(1)).findById(categoryId);
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 전체 조회")
+    class GetCategoriesTest {
+        @Test
+        @DisplayName("성공: 활성 카테고리를 정렬 순서대로 DTO 리스트로 반환한다")
+        void success() {
+            // given
+            Category category1 = mock(Category.class);
+            Category category2 = mock(Category.class);
+
+            when(categoryRepository.findActiveCategoriesOrderBySortOrder()).thenReturn(List.of(category1, category2));
+
+            CategoryResDto dto1 = mock(CategoryResDto.class);
+            CategoryResDto dto2 = mock(CategoryResDto.class);
+
+            try (MockedStatic<CategoryResDto> mocked = mockStatic(CategoryResDto.class)) {
+                mocked.when(() -> CategoryResDto.from(category1)).thenReturn(dto1);
+                mocked.when(() -> CategoryResDto.from(category2)).thenReturn(dto2);
+
+                // when
+                List<CategoryResDto> result = categoryService.getCategories();
+
+                // then
+                assertNotNull(result);
+                assertEquals(2, result.size());
+                assertSame(dto1, result.get(0));
+                assertSame(dto2, result.get(1));
+
+                verify(categoryRepository, times(1)).findActiveCategoriesOrderBySortOrder();
+            }
+        }
+
+        @Test
+        @DisplayName("실패: 등록된 카테고리가 없으면 예외가 발생한다")
+        void failNotFoundCategories() {
+            // given
+            when(categoryRepository.findActiveCategoriesOrderBySortOrder()).thenReturn(List.of());
+
+            // when & then
+            BusinessException exception = assertThrows(BusinessException.class, () -> categoryService.getCategories());
+
+            assertEquals(CategoryErrorCode.NOT_FOUND_CATEGORIES, exception.getErrorCode());
+            verify(categoryRepository, times(1)).findActiveCategoriesOrderBySortOrder();
+        }
+    }
+
+    @Nested
+    @DisplayName("관리자 카테고리 목록 조회")
+    class GetCategoriesAdminTest {
+
+        @Test
+        @DisplayName("성공: 조건에 맞는 카테고리를 페이징 조회한다")
+        void success() {
+            // given
+            int page = 0;
+            int size = 10;
+            String sortBy = "sortOrder";
+            boolean isAsc = true;
+            String name = "한";
+            boolean isDeleted = false;
+
+            Page<CategoryAdminResDto> response = new PageImpl<>(List.of(mock(CategoryAdminResDto.class)), PageRequest.of(page, size), 1);
+
+            when(categoryCustomRepository.searchCategoriesAdmin(any(Pageable.class), eq(name), eq(isDeleted)))
+                    .thenReturn(response);
+
+            // when
+            Page<CategoryAdminResDto> result = categoryService.getCategoriesAdmin(page, size, sortBy, isAsc, name, isDeleted);
+
+            // then
+            assertNotNull(result);
+            assertEquals(1, result.getTotalElements());
+
+            ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+            verify(categoryCustomRepository, times(1)).searchCategoriesAdmin(pageableCaptor.capture(), eq(name), eq(isDeleted));
+
+            Pageable pageableArg = pageableCaptor.getValue();
+            assertEquals(page, pageableArg.getPageNumber());
+            assertEquals(size, pageableArg.getPageSize());
+            assertEquals(Sort.Direction.ASC, pageableArg.getSort().getOrderFor(sortBy).getDirection());
+        }
+
+        @Test
+        @DisplayName("실패: 조회 결과가 없으면 NOT_FOUND_CATEGORIES 예외가 발생한다")
+        void failNotFoundCategories() {
+            // given
+            when(categoryCustomRepository.searchCategoriesAdmin(any(Pageable.class), any(), any())).thenReturn(Page.empty());
+
+            // when & then
+            BusinessException ex = assertThrows(BusinessException.class, () -> categoryService.getCategoriesAdmin(0, 10, "createdAt", true, null, false));
+
+            assertEquals(CategoryErrorCode.NOT_FOUND_CATEGORIES, ex.getErrorCode());
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

## 📌 작업 내용
- Category 관련 Service 테스트 코드를 Mock을 사용하여 구현
- Category 관련 Repository 테스트 코드를 @DataJpaTest 사용하여 구현

✅ 주요 변경 사항
- CategoryQueryServiceImpl 테스트 구현
- CategoryCommandService 테스트 구현
- CategoryRepository 테스트 구현
- CategoryCustomRepository 테스트 구현

## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인
- [x] 예외 케이스 확인 (해당 시)

### 확인 방법 (선택)
1. 내장 DB 실행 확인
2. 
3. 

## ⚠️ 영향 범위 (해당 시 체크)
- [ ] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정

## 👀 리뷰 포인트 (선택)
