### PR TITLE
[Feat] 주문 도메인 커서 기반 주문 이력 조회 및 상태별 통계 API 구현

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/order/application/converter/OrderConverter.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/converter/OrderConverter.java
@@ -3,8 +3,10 @@ package com.dfdt.delivery.domain.order.application.converter;
 import com.dfdt.delivery.common.infrastructure.persistence.embedded.CreateAudit;
 import com.dfdt.delivery.common.infrastructure.persistence.embedded.UpdateAudit;
 import com.dfdt.delivery.domain.address.domain.entity.Address;
+import com.dfdt.delivery.domain.order.application.dto.TimeIdCursor;
 import com.dfdt.delivery.domain.order.domain.entity.Order;
 import com.dfdt.delivery.domain.order.domain.entity.OrderItem;
+import com.dfdt.delivery.domain.order.domain.entity.OrderStatusHistory;
 import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
 import com.dfdt.delivery.domain.product.domain.entity.Product;
@@ -12,6 +14,8 @@ import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.user.domain.entity.User;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class OrderConverter {
 
@@ -34,6 +38,7 @@ public class OrderConverter {
                 .deliveryAddressSnapshot(addressSnapshot)
                 .orderRequestMessage(requestMessage)
                 .totalPrice(0)
+                .totalQuantity(0)
                 .status(OrderStatus.PENDING)
                 .createdAudit(CreateAudit.now(user.getName()))
                 .updateAudit(UpdateAudit.empty())
@@ -63,6 +68,7 @@ public class OrderConverter {
                 .orderAddress(order.getDeliveryAddressSnapshot())
                 .representativeProductName(generateOrderSummary(order.getOrderItems())) // 로직 추가
                 .totalPrice(order.getTotalPrice())
+                .totalQuantity(order.getTotalQuantity())
                 .orderRequestMessage(order.getOrderRequestMessage())
                 .orderStatus(order.getStatus())
                 .updatedAt(order.getUpdateAudit().getUpdatedAt())
@@ -82,5 +88,123 @@ public class OrderConverter {
         return (otherCount > 0)
                 ? String.format("%s 외 %d건", firstProductName, otherCount)
                 : firstProductName;
+    }
+
+    public static OrderResDto.CustomerOrderResponse toCustomerOrderResponse(List<Order> orders,int pageSize) {
+        boolean hasNext = orders.size() > pageSize;
+
+        List<Order> displayOrders = hasNext
+                ? orders.subList(0, pageSize)
+                : orders;
+        String nextCursor = null;
+        if (!displayOrders.isEmpty()) {
+            TimeIdCursor cursor = new TimeIdCursor(displayOrders.getLast());
+            nextCursor = cursor.getCursorString();
+        }
+
+        return OrderResDto.CustomerOrderResponse.builder()
+                .orderList(displayOrders.stream().map(OrderConverter::toCustomerOrderSummary).toList())
+                .pagination(OrderResDto.PaginationInfo.builder()
+                        .nextCursor(nextCursor)
+                        .hasNext(hasNext)
+                        .size(displayOrders.size())
+                        .build())
+                .build();
+    }
+
+    private static OrderResDto.CustomerOrderSummary toCustomerOrderSummary(Order order) {
+        return OrderResDto.CustomerOrderSummary.builder()
+                .orderId(order.getOrderId())
+                .orderAddress(order.getDeliveryAddressSnapshot())
+                .orderedAt(order.getCreatedAudit().getCreatedAt())
+                .orderStatus(order.getStatus())
+                .orderStoreId(order.getStore().getStoreId())
+                .orderStoreName(order.getStore().getName())
+                .representativeProductName(generateOrderSummary(order.getOrderItems()))
+                .totalPrice(order.getTotalPrice())
+                .totalQuantity(order.getTotalQuantity())
+                .build();
+    }
+
+    public static OrderResDto.GetOrderDetailResponse toOrderDetailResponse(Order order) {
+        return OrderResDto.GetOrderDetailResponse.builder()
+                .orderId(order.getOrderId())
+                .orderAddress(order.getDeliveryAddressSnapshot())
+                .orderedAt(order.getCreatedAudit().getCreatedAt())
+                .orderStatus(order.getStatus())
+                .orderStoreId(order.getStore().getStoreId())
+                .orderItemDetails(order.getOrderItems().stream().map(OrderConverter::toOrderItemDetail).toList())
+                .orderStoreName(order.getStore().getName())
+                .totalPrice(order.getTotalPrice())
+                .totalQuantity(order.getTotalQuantity())
+                .orderStatusHistoryDetails(order.getStatusHistories().stream().map(OrderConverter::toOrderHistoryDetail).toList())
+                .build();
+    }
+
+    private static OrderResDto.OrderStatusHistoryDetail toOrderHistoryDetail(OrderStatusHistory orderStatusHistory) {
+        return OrderResDto.OrderStatusHistoryDetail.builder()
+                .orderStatusHistoryId(orderStatusHistory.getOrderStatusHistoryId())
+                .fromStatus(orderStatusHistory.getFromStatus())
+                .nowStatus(orderStatusHistory.getToStatus())
+                .changedAt(orderStatusHistory.getCreatedAudit().getCreatedAt())
+                .changedReason(orderStatusHistory.getChangeReason())
+                .build();
+    }
+
+    private static OrderResDto.OrderItemResponse toOrderItemDetail(OrderItem orderItem) {
+        return OrderResDto.OrderItemResponse.builder()
+                .productId(orderItem.getProductId())
+                .productName(orderItem.getProductNameSnapshot())
+                .unitPrice(orderItem.getUnitPriceSnapshot())
+                .totalPrice(orderItem.getTotalPrice())
+                .quantity(orderItem.getQuantity())
+                .build();
+    }
+
+    public static OrderResDto.OwnerDashboardResponse toOwnerDashboardResponse(OrderResDto.OrderSummaryCount summaryCounts, int pageSize, List<Order> orders) {
+
+        boolean hasNext = orders.size() > pageSize;
+
+        List<Order> displayOrders = hasNext
+                ? orders.subList(0, pageSize)
+                : orders;
+        String nextCursor = null;
+        if (!displayOrders.isEmpty()) {
+            TimeIdCursor cursor = new TimeIdCursor(displayOrders.getLast());
+            nextCursor = cursor.getCursorString();
+        }
+
+        Map<OrderStatus, List<OrderResDto.OwnerOrderUnit>> statusGroups = displayOrders.stream()
+                .collect(Collectors.groupingBy(
+                        Order::getStatus, // 그룹핑 기준 (Key)
+                        Collectors.mapping(
+                                OrderConverter::toOwnerOrderUnit,
+                                Collectors.toList()
+                        )
+                ));
+
+        return OrderResDto.OwnerDashboardResponse.builder()
+                .summary(summaryCounts)
+                .statusGroups(statusGroups)
+                .pagination(OrderResDto.PaginationInfo.builder()
+                        .nextCursor(nextCursor)
+                        .hasNext(hasNext)
+                        .size(displayOrders.size())
+                        .build())
+                .build();
+    }
+    private static OrderResDto.OwnerOrderUnit toOwnerOrderUnit(Order order) {
+        return OrderResDto.OwnerOrderUnit.builder()
+                .orderId(order.getOrderId())
+                .orderAddress(order.getDeliveryAddressSnapshot())
+                .orderTime(order.getCreatedAudit().getCreatedAt())
+                .totalPrice(order.getTotalPrice())
+                .totalQuantity(order.getTotalQuantity())
+                .products(order.getOrderItems().stream().map(
+                        product->
+                        new OrderResDto.ProductSimpleInfo(product.getProductId(), product.getQuantity(), product.getProductNameSnapshot())
+                ).toList())
+                .build();
+
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/application/dto/TimeIdCursor.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/dto/TimeIdCursor.java
@@ -1,0 +1,45 @@
+package com.dfdt.delivery.domain.order.application.dto;
+
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.time.OffsetDateTime;
+import java.util.Base64;
+import java.util.UUID;
+
+@Getter
+@Setter
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class TimeIdCursor {
+    private OffsetDateTime time;
+    private UUID id;
+
+    public TimeIdCursor(Order order)
+    {
+        this.time = order.getCreatedAudit().getCreatedAt();
+        this.id = order.getOrderId();
+    }
+
+    public TimeIdCursor(String cursorString) {
+        byte[] decodedBytes = Base64.getDecoder().decode(cursorString.getBytes());
+        String decodedBytesString = new String(decodedBytes);
+        String[] split = decodedBytesString.split(",");
+        this.id = UUID.fromString(split[0]);
+        this.time = OffsetDateTime.parse(split[1]);
+    }
+    public String getCursorString()
+    {
+        try {
+            String s = this.id + "," + this.time;
+            byte[] base64EncodedBytes = Base64.getEncoder().encode(s.getBytes());
+            return new String(base64EncodedBytes);
+        } catch (Exception e) {
+            return null;
+        }
+
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/OrderExpirationService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/OrderExpirationService.java
@@ -9,8 +9,8 @@ import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
 import com.dfdt.delivery.domain.order.infrastructure.persistence.redis.OrderRedisService;
 import com.dfdt.delivery.domain.payment.application.service.command.PaymentCommandService;
 import com.dfdt.delivery.domain.payment.domain.enums.PaymentErrorCode;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,13 +18,22 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.UUID;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class OrderExpirationService {
 
+    // 순환 참조로 인해 Lazy 방식 이용
     private final OrderRepository orderRepository;
-    private final PaymentCommandService paymentCommandService;
+    private final @Lazy PaymentCommandService paymentCommandService;
     private final OrderRedisService orderRedisService;
+
+    public OrderExpirationService(
+            OrderRepository orderRepository,
+            @Lazy PaymentCommandService paymentCommandService,
+            OrderRedisService orderRedisService) {
+        this.orderRepository = orderRepository;
+        this.paymentCommandService = paymentCommandService;
+        this.orderRedisService = orderRedisService;
+    }
 
     @Transactional
     public void completePayment(UUID orderId) {
@@ -40,7 +49,6 @@ public class OrderExpirationService {
         orderRedisService.setAcceptTimeout(orderId);
         log.info("주문 {}번: 결제 완료 처리 및 사장님 수락 타이머 시작", orderId);
     }
-
     /**
      * [1] 결제 시간 초과 이벤트 처리 (10분 만료)
      */
@@ -82,7 +90,7 @@ public class OrderExpirationService {
                         orderRepository.findPaymentOrderId(event.orderId())
                                 .ifPresentOrElse(payment -> {
                                     log.info("결제 취소 요청 실행: 결제ID {}", payment.getPaymentId());
-                                    paymentCommandService.cancelPayment(payment.getPaymentId());
+                                    paymentCommandService.cancelPayment(payment.getPaymentId(),order.getUser().getUsername());
                                 }
                                 , () -> {
                                     throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_STATUS);});

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/command/OrderCommandServiceImpl.java
@@ -1,9 +1,10 @@
 package com.dfdt.delivery.domain.order.application.service.command;
 
 import com.dfdt.delivery.domain.address.domain.entity.Address;
+import com.dfdt.delivery.domain.address.domain.repository.AddressRepository;
 import com.dfdt.delivery.domain.order.application.converter.OrderConverter;
 import com.dfdt.delivery.domain.order.application.provider.OrderDataFinder;
-import com.dfdt.delivery.domain.order.application.service.checker.OrderPreConditionChecker;
+import com.dfdt.delivery.domain.order.application.service.validator.OrderValidator;
 import com.dfdt.delivery.domain.order.domain.entity.Order;
 import com.dfdt.delivery.domain.order.domain.entity.OrderItem;
 import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
@@ -12,26 +13,28 @@ import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
 import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
 import com.dfdt.delivery.domain.payment.application.service.command.PaymentCommandService;
-import com.dfdt.delivery.domain.payment.domain.entity.Payment;
 import com.dfdt.delivery.domain.payment.presentation.dto.request.PaymentCreateReqDto;
 import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.product.domain.repository.JpaProductRepository;
 import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.user.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Duration;
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class OrderCommandServiceImpl implements OrderCommandService {
     private final OrderRedisService orderRedisService;
     private final OrderRepository orderRepository;
-    private final OrderPreConditionChecker orderPreConditionChecker;
+    private final OrderValidator orderValidator;
     private final OrderDataFinder orderDataFinder;
     private final PaymentCommandService paymentCommandService;
+    private final AddressRepository addressRepository;
+    private final JpaProductRepository productRepository;
 
 
     @Transactional
@@ -43,7 +46,8 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         User orderUser = orderDataFinder.findUser(username);
 
         List<UUID> productIds = createDTO.orderItems().stream().map(OrderReqDto.OrderItem::productId).toList();
-        Map<UUID, Product> stockMap = orderDataFinder.getProductMap(productIds);
+        Map<UUID, Product> stockMap = productRepository.findAllById(productIds).stream()
+                .collect(Collectors.toMap(Product::getProductId, p -> p));
 
         // 주문 생성
         Order order = OrderConverter.toOrder(orderUser,orderAddress,orderStore,createDTO.requestMemo());
@@ -51,7 +55,7 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         for (OrderReqDto.OrderItem productItem : createDTO.orderItems()) {
             Product stock = stockMap.get(productItem.productId());
             // 매장의 상품이 존재하는 지, 재고가 있는지 확인하는 함수
-            orderPreConditionChecker.validateProduct(stock,orderStore,productItem);
+            orderValidator.validateProduct(stock,orderStore,productItem);
             // 주문 아이템 생성
             OrderItem orderItem = OrderConverter.toOrderItem(stock, productItem.quantity());
             order.addOrderItem(orderItem);
@@ -78,12 +82,13 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         User user = orderDataFinder.findUser(username);
 
         // 권한 체크 ( 주문의 주인인지 )
-        orderPreConditionChecker.authoriseOrderCustomer(order,user);
-        orderPreConditionChecker.validateModifiable(order);
+        orderValidator.authoriseOrderCustomer(order,user);
+        orderValidator.validateModifiable(order);
 
         if (updateOrderDTO.addressId()!=null)
         {
-            Address orderAddress = orderDataFinder.findAddress(updateOrderDTO.addressId());
+            Address orderAddress = addressRepository.findById(updateOrderDTO.addressId())
+                    .orElseThrow(() -> new NoSuchElementException("주소를 찾을 수 없습니다."));
             order.updateAddress(orderAddress);
         }
         if (updateOrderDTO.requestMemo()!=null)
@@ -100,8 +105,8 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         User user = orderDataFinder.findUser(username);
 
         // 권한 체크
-        orderPreConditionChecker.authoriseOrderCustomer(order,user);
-        orderPreConditionChecker.validateDeletable(order);
+        orderValidator.authoriseOrderCustomer(order,user);
+        orderValidator.validateDeletable(order);
 
         // 상태별 로직 분기
         if (order.getStatus() == OrderStatus.PENDING)
@@ -121,15 +126,14 @@ public class OrderCommandServiceImpl implements OrderCommandService {
         User user = orderDataFinder.findUser(username);
 
         // 전체 권한 체크
-        orderPreConditionChecker.authoriseOrder(order,user);
-        orderPreConditionChecker.validateStatusUpdatable(user,order,updateStatusDTO.orderStatus());
+        orderValidator.authoriseOrder(order,user);
+        orderValidator.validateStatusUpdatable(user,order,updateStatusDTO.orderStatus());
 
         if (order.getStatus() == OrderStatus.PAID && updateStatusDTO.orderStatus() == OrderStatus.REJECTED)
         {
             orderRepository.findPaymentOrderId(orderId)
-                    .ifPresent(payment -> {
-                        paymentCommandService.cancelPayment(payment.getPaymentId());
-                    });
+                    .ifPresent(payment ->
+                        paymentCommandService.cancelPayment(payment.getPaymentId(),username));
         }
         // 권한 수정
         order.updateStatus(updateStatusDTO.orderStatus(), updateStatusDTO.changedReason());

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/query/OrderQueryService.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/query/OrderQueryService.java
@@ -1,7 +1,12 @@
 package com.dfdt.delivery.domain.order.application.service.query;
 
-import org.springframework.stereotype.Service;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
 
-@Service
-public class OrderQueryService {
+import java.util.UUID;
+
+public interface OrderQueryService {
+    OrderResDto.CustomerOrderResponse getCustomerOrderHistory(String username, OrderReqDto.OrderSearchRequest orderSearchRequest);
+    OrderResDto.GetOrderDetailResponse getOrderDetail(String username, UUID orderId);
+    OrderResDto.OwnerDashboardResponse getOwnerDashboard(String username, UUID storeId,OrderReqDto.OrderSearchRequest orderSearchRequest);
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/query/OrderQueryServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/query/OrderQueryServiceImpl.java
@@ -1,0 +1,116 @@
+package com.dfdt.delivery.domain.order.application.service.query;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.common.exception.error.enums.UserErrorCode;
+import com.dfdt.delivery.domain.order.application.converter.OrderConverter;
+import com.dfdt.delivery.domain.order.application.dto.TimeIdCursor;
+import com.dfdt.delivery.domain.order.application.provider.OrderDataFinder;
+import com.dfdt.delivery.domain.order.application.service.validator.OrderValidator;
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.domain.entity.QOrder;
+import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderReqDto;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.repository.UserRepository;
+import com.querydsl.core.BooleanBuilder;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class OrderQueryServiceImpl implements OrderQueryService {
+    private final OrderRepository orderRepository;
+    private final OrderDataFinder orderDataFinder;
+    private final UserRepository userRepository;
+    private final OrderValidator orderValidator;
+    private final QOrder order = QOrder.order;
+
+
+    @Override
+    public OrderResDto.CustomerOrderResponse getCustomerOrderHistory(String username, OrderReqDto.OrderSearchRequest orderSearchRequest) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 첫번째 조건 : 내 주문만 가져오기
+        builder.and(order.user.username.eq(username));
+
+        if (orderSearchRequest.statuses() != null && !orderSearchRequest.statuses().isEmpty())
+            builder.and(order.status.in(orderSearchRequest.statuses()));
+        if (orderSearchRequest.startDate() != null && orderSearchRequest.endDate() != null) {
+            builder.and(
+                    order.createdAudit.createdAt.between(
+                            orderSearchRequest.startDate(), orderSearchRequest.endDate()));
+        }
+
+        if (orderSearchRequest.cursor() != null)
+        {
+            TimeIdCursor cursor = new TimeIdCursor(orderSearchRequest.cursor());
+            builder.and(
+                    order.createdAudit.createdAt.lt(cursor.getTime())
+                            .or(order.createdAudit.createdAt.eq(cursor.getTime())
+                                    .and(order.orderId.lt(cursor.getId())))
+            );
+        }
+
+        int pageSize = orderSearchRequest.size();
+        List<Order> orders = orderRepository.findAllByBuilder(pageSize,builder);
+        log.info("사용자의 주문 목록 조회 완료");
+        // 컨버터 변환
+        return OrderConverter.toCustomerOrderResponse(orders,pageSize);
+    }
+
+
+    @Transactional
+    @Override
+    public OrderResDto.GetOrderDetailResponse getOrderDetail(String username, UUID orderId) {
+        Order order = orderDataFinder.findOrder(orderId);
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(()-> new BusinessException(UserErrorCode.INVALID_AUTH_REQUEST));
+
+        orderValidator.authoriseOrder(order,user);
+        return OrderConverter.toOrderDetailResponse(order);
+    }
+
+    @Override
+    public OrderResDto.OwnerDashboardResponse getOwnerDashboard(String username, UUID storeId,OrderReqDto.OrderSearchRequest orderSearchRequest) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 첫번째 조건 : 가게 주문 가져오기
+        builder.and(order.store.user.username.eq(username));
+        builder.and(order.store.storeId.eq(storeId));
+
+        if (orderSearchRequest.startDate() != null && orderSearchRequest.endDate() != null) {
+            builder.and(
+                    order.createdAudit.createdAt.between(
+                            orderSearchRequest.startDate(), orderSearchRequest.endDate()));
+        }
+
+        OrderResDto.OrderSummaryCount summaryCounts = orderRepository.countOrdersByStatus(builder);
+
+        if (orderSearchRequest.statuses() != null && !orderSearchRequest.statuses().isEmpty())
+            builder.and(order.status.in(orderSearchRequest.statuses()));
+
+        if (orderSearchRequest.cursor() != null)
+        {
+            TimeIdCursor cursor = new TimeIdCursor(orderSearchRequest.cursor());
+            builder.and(
+                    order.createdAudit.createdAt.lt(cursor.getTime())
+                            .or(order.createdAudit.createdAt.eq(cursor.getTime())
+                                    .and(order.orderId.lt(cursor.getId())))
+            );
+        }
+        
+        int pageSize = orderSearchRequest.size();
+        List<Order> orders = orderRepository.findAllByBuilder(pageSize,builder);
+        log.info("가게의 주문 목록 조회 완료");
+        // 컨버터 변환
+        return OrderConverter.toOwnerDashboardResponse(summaryCounts,pageSize,orders);
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/application/service/validator/OrderValidator.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/application/service/validator/OrderValidator.java
@@ -1,4 +1,4 @@
-package com.dfdt.delivery.domain.order.application.service.checker;
+package com.dfdt.delivery.domain.order.application.service.validator;
 
 import com.dfdt.delivery.common.exception.BusinessException;
 import com.dfdt.delivery.domain.order.domain.entity.Order;
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 import java.util.Objects;
 
 @Component
-public class OrderPreConditionChecker {
+public class OrderValidator {
 
     public void validateProduct(Product product, Store orderStore, OrderReqDto.OrderItem itemReq) {
         if (product == null || product.getIsHidden()) {
@@ -35,7 +35,6 @@ public class OrderPreConditionChecker {
     public void authoriseOrder(Order order, User user) {
         // 1. 고객인 경우: 본인 주문만 접근 가능
         if (user.getRole() == UserRole.CUSTOMER) {
-            System.out.println(order.getUser().getUsername()+ user.getUsername());
             if (!Objects.equals(order.getUser().getUsername(), user.getUsername())) {
                 throw new BusinessException(OrderErrorCode.ACCESS_DENIED);
             }

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/entity/Order.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/entity/Order.java
@@ -52,6 +52,9 @@ public class Order {
     @Column(name = "total_price", nullable = false)
     private Integer totalPrice;
 
+    @Column(name = "total_quantity",nullable = false)
+    private Integer totalQuantity;
+
     @Column(name = "order_request_message", length = 255)
     private String orderRequestMessage;
 
@@ -76,6 +79,7 @@ public class Order {
     public void addOrderItem(OrderItem item) {
         this.orderItems.add(item);
         this.totalPrice += item.getTotalPrice();
+        this.totalQuantity += item.getQuantity();
         item.setOrder(this);
     }
     public void addStatusHistory(OrderStatus from, OrderStatus to, String reason) {

--- a/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/domain/repository/OrderRepository.java
@@ -1,14 +1,21 @@
 package com.dfdt.delivery.domain.order.domain.repository;
 
 import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.infrastructure.persistence.repository.JpaOrderRepository;
+import com.dfdt.delivery.domain.order.infrastructure.persistence.repository.QueryDslOrderRepository;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
 import com.dfdt.delivery.domain.payment.domain.entity.Payment;
+import com.querydsl.core.BooleanBuilder;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface OrderRepository {
+public interface OrderRepository extends JpaOrderRepository, QueryDslOrderRepository {
     Order save(Order order);
     Optional<Order> findById(UUID orderId);
     Optional<Order> findByIdWithLock(UUID orderId);
     Optional<Payment> findPaymentOrderId(UUID orderId);
+    List<Order> findAllByBuilder(int pageSize, BooleanBuilder builder);
+    OrderResDto.OrderSummaryCount countOrdersByStatus(BooleanBuilder builder);
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/listener/OrderRedisKeyExpirationListener.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/listener/OrderRedisKeyExpirationListener.java
@@ -3,6 +3,7 @@ package com.dfdt.delivery.domain.order.infrastructure.listener;
 import com.dfdt.delivery.domain.order.domain.enums.OrderRedisPrefix;
 import com.dfdt.delivery.domain.order.domain.event.OrderEvent;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
@@ -17,7 +18,7 @@ public class OrderRedisKeyExpirationListener extends KeyExpirationEventMessageLi
     private final ApplicationEventPublisher applicationEventPublisher;
 
     public OrderRedisKeyExpirationListener
-            (RedisMessageListenerContainer listenerContainer,
+            (@Qualifier("redisMessageListenerContainer") RedisMessageListenerContainer listenerContainer,
              ApplicationEventPublisher applicationEventPublisher) {
         super(listenerContainer);
         this.applicationEventPublisher = applicationEventPublisher;

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/JpaOrderRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/JpaOrderRepository.java
@@ -1,7 +1,6 @@
 package com.dfdt.delivery.domain.order.infrastructure.persistence.repository;
 
 import com.dfdt.delivery.domain.order.domain.entity.Order;
-import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
 import com.dfdt.delivery.domain.payment.domain.entity.Payment;
 import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,14 +10,12 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface JpaOrderRepository extends JpaRepository<Order, UUID> , OrderRepository {
+public interface JpaOrderRepository extends JpaRepository<Order, UUID> {
 
-    @Override
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select o from Order o where o.orderId = :orderId")
     Optional<Order> findByIdWithLock(UUID orderId);
 
-    @Override
     @Query("select p from Payment  p where  p.orderId = :orderId")
     Optional<Payment> findPaymentOrderId(UUID orderId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/QueryDslOrderRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/QueryDslOrderRepository.java
@@ -1,0 +1,12 @@
+package com.dfdt.delivery.domain.order.infrastructure.persistence.repository;
+
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
+import com.querydsl.core.BooleanBuilder;
+
+import java.util.List;
+
+public interface QueryDslOrderRepository {
+    List<Order> findAllByBuilder(int pageSize, BooleanBuilder builder);
+    OrderResDto.OrderSummaryCount countOrdersByStatus(BooleanBuilder builder);
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/QueryDslOrderRepositoryImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/infrastructure/persistence/repository/QueryDslOrderRepositoryImpl.java
@@ -1,0 +1,68 @@
+package com.dfdt.delivery.domain.order.infrastructure.persistence.repository;
+
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
+import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.dfdt.delivery.domain.order.domain.entity.QOrder.order;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryDslOrderRepositoryImpl implements QueryDslOrderRepository {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Order> findAllByBuilder(int pageSize, BooleanBuilder builder) {
+
+        return queryFactory
+                .selectFrom(order)
+                .where(builder)
+                .orderBy(
+                        order.createdAudit.createdAt.desc()
+                        ,order.orderId.desc()) // 최신순 정렬
+                .limit(pageSize + 1) // nextCursor를 위해 하나 더 조회
+                .fetch();
+    }
+    @Override
+    public OrderResDto.OrderSummaryCount countOrdersByStatus(BooleanBuilder builder) {
+        return queryFactory
+                .select(Projections.constructor(OrderResDto.OrderSummaryCount.class,
+
+                        // 1. newOrderCount: 결제 완료
+                        new CaseBuilder()
+                                .when(order.status.eq(OrderStatus.PAID))
+                                .then(1).otherwise(0).sum(),
+
+                        // 2. cookingCount: 수락됨
+                        new CaseBuilder()
+                                .when(order.status.eq(OrderStatus.ACCEPTED))
+                                .then(1).otherwise(0).sum(),
+
+                        // 3. deliveryCount: 조리완료 or 배달중
+                        new CaseBuilder()
+                                .when(order.status.in(OrderStatus.COOKING_DONE, OrderStatus.DELIVERING))
+                                .then(1).otherwise(0).sum(),
+
+                        // 4. completedCount: 배달완료 or 확정
+                        new CaseBuilder()
+                                .when(order.status.in(OrderStatus.DELIVERED, OrderStatus.COMPLETED))
+                                .then(1).otherwise(0).sum(),
+
+                        // 5. abortedCount: 거절 or 취소
+                        new CaseBuilder()
+                                .when(order.status.in(OrderStatus.REJECTED, OrderStatus.CANCELED))
+                                .then(1).otherwise(0).sum()
+                ))
+                .from(order)
+                .where(builder)
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderController.java
@@ -8,6 +8,7 @@ import com.dfdt.delivery.domain.order.presentation.dto.OrderResDto;
 import com.dfdt.delivery.domain.order.application.service.command.OrderCommandService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -39,12 +40,13 @@ public class OrderController implements OrderControllerDocs {
     // API-002 사용자의 주문 목록 조회
     @GetMapping()
     public ResponseEntity<ApiResponseDto<OrderResDto.CustomerOrderResponse>> getOrders(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @ParameterObject @Valid OrderReqDto.OrderSearchRequest searchRequest
     ){
         return ApiResponseDto.success(
                 200,
                 "사용자의 주문 목록을 조회하였습니다.",
-                null
+                orderQueryService.getCustomerOrderHistory(customUserDetails.getUsername(),searchRequest)
         );
     }
 
@@ -57,7 +59,7 @@ public class OrderController implements OrderControllerDocs {
         return ApiResponseDto.success(
                 200,
                 "해당 주문을 조회하였습니다.",
-                null
+                orderQueryService.getOrderDetail(customUserDetails.getUsername(),orderId)
         );
     }
 
@@ -105,12 +107,14 @@ public class OrderController implements OrderControllerDocs {
     // API-007 가게의 주문 목록 조회하기 ( 상태별 )
     @GetMapping("/store/{storeId}")
     public ResponseEntity<ApiResponseDto<OrderResDto.OwnerDashboardResponse>> getOrdersByOwner(
-            @PathVariable (value = "storeId") UUID  storeId
+            @PathVariable (value = "storeId") UUID  storeId,
+            @ParameterObject @Valid OrderReqDto.OrderSearchRequest orderSearchRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
     ) {
         return ApiResponseDto.success(
                 200,
                 "가게의 주문 목록이 조회되었습니다.",
-                null
+                orderQueryService.getOwnerDashboard(customUserDetails.getUsername(),storeId,orderSearchRequest)
         );
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/controller/OrderControllerDocs.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -50,7 +51,9 @@ public interface OrderControllerDocs {
             @ApiResponse(responseCode = "401", description = "인증되지 않은 사용자")
     })
     ResponseEntity<ApiResponseDto<OrderResDto.CustomerOrderResponse>> getOrders(
-            @AuthenticationPrincipal CustomUserDetails customUserDetails);
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @ParameterObject @Valid OrderReqDto.OrderSearchRequest orderSearchRequest
+    );
 
 
     @Operation(summary = "API-003 주문 상세 조회", description = "특정 주문에 대한 상세 정보를 조회합니다.")
@@ -133,5 +136,7 @@ public interface OrderControllerDocs {
             @ApiResponse(responseCode = "404", description = "가게 정보를 찾을 수 없음")
     })
     ResponseEntity<ApiResponseDto<OrderResDto.OwnerDashboardResponse>> getOrdersByOwner(
-            @PathVariable(value = "storeId") UUID storeId);
+            @PathVariable(value = "storeId") UUID storeId,
+            @ParameterObject @Valid OrderReqDto.OrderSearchRequest orderSearchRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderReqDto.java
@@ -4,7 +4,9 @@ import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
 import com.dfdt.delivery.domain.payment.domain.enums.PaymentMethod;
 import jakarta.validation.constraints.*;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.format.annotation.DateTimeFormat;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -39,4 +41,20 @@ public class OrderReqDto {
             OrderStatus orderStatus,
             String changedReason
     ){}
+    public record OrderSearchRequest(
+            @DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+            OffsetDateTime startDate,
+            @DateTimeFormat(iso = DateTimeFormat.ISO.TIME)
+            OffsetDateTime endDate,
+
+            List<OrderStatus> statuses,
+
+            String cursor,
+            @Max(100)
+            Integer size
+    ){
+        public OrderSearchRequest {
+            if (size == null || size <= 0) size = 10;
+        }
+    }
 }

--- a/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderResDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/order/presentation/dto/OrderResDto.java
@@ -29,7 +29,6 @@ public class OrderResDto {
             String orderAddress,
             OrderStatus orderStatus
     ){}
-
     // 가게용 GET
     @Builder
     public record OwnerDashboardResponse(
@@ -40,11 +39,11 @@ public class OrderResDto {
 
     @Builder
     public record OrderSummaryCount(
-            Integer pendingCount,
-            Integer paidCount,
-            Integer cookingCount,
-            Integer doneCount,
-            Integer canceledCount
+            Integer newOrderCount,     // [신규] PAID (수락 대기 중인 주문)
+            Integer cookingCount,      // [조리 중] ACCEPTED (현재 만들고 있는 주문)
+            Integer deliveryCount,     // [배달 중] COOKING_DONE + DELIVERING (전달 대기 및 배달 중)
+            Integer completedCount,    // [완료] DELIVERED + COMPLETED (완료)
+            Integer abortedCount       // [취소/거절] REJECTED + CANCELED (중단된 주문)
     ){}
 
     @Builder
@@ -64,7 +63,7 @@ public class OrderResDto {
             UUID orderStoreId,
             String orderStoreName,
             OffsetDateTime orderedAt,
-            Long totalPrice,
+            Integer totalPrice,
             Integer totalQuantity,
             String orderAddress,
             OrderStatus orderStatus,
@@ -77,8 +76,8 @@ public class OrderResDto {
             UUID productId,
             String productName,
             Integer quantity,
-            Long unitPrice,
-            Long totalPrice
+            Integer unitPrice,
+            Integer totalPrice
     ){}
 
     @Builder
@@ -93,6 +92,7 @@ public class OrderResDto {
     @Builder
     public record ProductSimpleInfo(
             UUID productId,
+            Integer size,
             String productName
     ){}
     
@@ -102,6 +102,7 @@ public class OrderResDto {
             UUID orderId,
             OrderStatus orderStatus,
             String orderAddress,
+            Integer totalQuantity,
             Integer totalPrice,
             String representativeProductName,
             String orderRequestMessage,
@@ -111,7 +112,7 @@ public class OrderResDto {
     // 페이징 응답
     @Builder
     public record PaginationInfo(
-            OffsetDateTime nextCursor,
+            String nextCursor,
             Integer size,
             boolean hasNext
     ){}


### PR DESCRIPTION

## 🔗 관련 이슈
- Closes #6 

## 📌 작업 내용
주문 시스템의 핵심 기능인 **커서 기반 페이지네이션** 및 **사장님용 대시보드 통계 조회** 기능을 구현하고, 서비스 레이어의 책임을 분리하는 리팩토링을 진행했습니다.

## ✅ 주요 변경 사항
- **QueryDSL 도입 및 커서 페이징 구현**: `OffsetDateTime`과 `UUID`를 조합한 복합 커서(`TimeIdCursor`)를 사용하여 No-Offset 방식의 고성능 페이징을 구현했습니다. 인코딩 & 디코딩 방식 사용
- 조회 Req 추가 : 커서, status, 기간 , 사이즈 ( 전체 null 가능 ) 
- **사장님 대시보드 통계 서비스**: `CaseBuilder`를 활용해 한 번의 쿼리로 5가지 주문 상태별 카운트(`new`, `cooking`, `delivery`, `completed`, `aborted`)를 집계하는 기능을 추가했습니다.
- **레포지토리 구조 리팩토링**: 상속 구조 변경
- **안정성 강화**: 결제 만료 및 수락 타임아웃 처리 로직의 버그를 수정하고, `OrderValidator`를 통한 권한 및 상태 검증 로직을 강화했습니다.

## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인: Postman을 통한 사용자 주문 이력 및 사장님 대시보드 API 호출 테스트 완료
- [x] 주요 시나리오 동작 확인: 주문 생성 -> 결제 완료 -> 사장님 수락 -> 배달 완료 흐름 확인
- [x] 예외 케이스 확인: 존재하지 않는 커서 입력 시 처리, 다른 사람의 주문 조회 시 `ACCESS_DENIED` 발생 확인

> 커서 응답 예시

```json        
"pagination": {
            "nextCursor": "YTA5MmE0YzktNmQ3Ni00ZGIyLWFhZDgtYTMwOTE4MDU2Y2NhLDIwMjYtMDMtMDZUMTI6NDA6MDIuMjcxNTczWg==",
            "size": 6,
            "hasNext": false
        }
```



### 확인 방법
1. `GET /api/v1/orders` 호출 시 `cursor` 파라미터 유무에 따른 페이징 동작 확인
2. `GET /api/v1/orders/{orderId}` 호출 시 데이터 수신 확인
3. `GET /api/v1/orders/store/{storeId}` 호출 시 데이터 포맷 확인

## ⚠️ 영향 범위 (해당 시 체크)
- [x] API 스펙 변경
- [ ] DB 스키마 변경
- [x] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [x] 문서(Swagger/README) 수정

## 트러블 슈팅
- TimeZone
- Paging 방식 결정 : 커서 페이징, 인코딩된 커서 도입
- 의존성 순환 참조 : Lazy 방식 도입

## 참고 사항
[Querydsl을 이용한 커서 기반 페이지네이션 구현기](https://stop-thinking-start-now.tistory.com/210)
[Offset Paging vs Cursor Paging](https://velog.io/@pjh612/Offset-Paging-vs-Cursor-Paging)

## 👀 리뷰 포인트
- **QueryDslOrderRepositoryImpl**: `CaseBuilder`를 사용한 통계 쿼리가 Hibernate 6 환경에서 문법 오류 없이 효율적으로 동작하는지 확인 부탁드립니다.
- **TimeIdCursor**: Base64 인코딩/디코딩 과정에서 시각 데이터(`OffsetDateTime`)의 정밀도 손실이 없는지 검토 바랍니다.
- **OrderConverter**: `groupingBy`를 통한 상태별 그룹화 로직이 `pageSize + 1` 전략과 충돌하지 않는지(마지막 더미 데이터 제외 여부) 확인해 주세요.