### PR TITLE
[Feat] 리뷰 도메인 조회 기능 구현

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/review/application/converter/ReviewConverter.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/application/converter/ReviewConverter.java
@@ -16,16 +16,18 @@ public class ReviewConverter {
                 .reviewId(review.getReviewId())
                 .username(review.getWriterUsername())
                 .storeName(store.getName())
-                .orderMenuNames(order.getOrderItems().stream()
-                        .map(OrderItem::getProductNameSnapshot)
-                        .collect(Collectors.toList()))
+                .orderMenuNames(order.getOrderItems() != null ? 
+                        order.getOrderItems().stream()
+                            .map(OrderItem::getProductNameSnapshot)
+                            .collect(Collectors.toList()) : java.util.Collections.emptyList())
                 .rating(review.getRating())
                 .content(review.getContent())
-                .images(review.getImages().stream()
-                        .map(ReviewImage::getImageUrl)
-                        .collect(Collectors.toList()))
-                .createdAt(review.getCreateAudit().getCreatedAt())
-                .updatedAt(review.getUpdateAudit().getUpdatedAt())
+                .images(review.getImages() != null ? 
+                        review.getImages().stream()
+                            .map(ReviewImage::getImageUrl)
+                            .collect(Collectors.toList()) : java.util.Collections.emptyList())
+                .createdAt(review.getCreateAudit() != null ? review.getCreateAudit().getCreatedAt() : null)
+                .updatedAt(review.getUpdateAudit() != null ? review.getUpdateAudit().getUpdatedAt() : null)
                 .build();
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/review/application/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/application/service/query/ReviewQueryServiceImpl.java
@@ -1,14 +1,23 @@
 package com.dfdt.delivery.domain.review.application.service.query;
 
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.review.application.converter.ReviewConverter;
 import com.dfdt.delivery.domain.review.application.provider.ReviewDataFinder;
 import com.dfdt.delivery.domain.review.application.service.validator.ReviewValidator;
+import com.dfdt.delivery.domain.review.domain.entity.Review;
+import com.dfdt.delivery.domain.review.domain.enums.ReviewErrorCode;
+import com.dfdt.delivery.domain.review.domain.repository.ReviewCustomRepository;
 import com.dfdt.delivery.domain.review.presentation.dto.request.MyReviewSearchReqDto;
 import com.dfdt.delivery.domain.review.presentation.dto.request.ReviewSearchReqDto;
 import com.dfdt.delivery.domain.review.presentation.dto.request.StoreReviewSearchReqDto;
 import com.dfdt.delivery.domain.review.presentation.dto.response.ReviewListResDto;
 import com.dfdt.delivery.domain.review.presentation.dto.response.ReviewResDto;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
 
@@ -18,44 +27,64 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
 
     private final ReviewValidator reviewValidator;
     private final ReviewDataFinder reviewDataFinder;
+    private final ReviewCustomRepository reviewCustomRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public ReviewListResDto getStoreReviews(UUID storeId, StoreReviewSearchReqDto request) {
 
         request.setSize(reviewValidator.validateAndAdjustSize(request.getSize()));
 
-        // TODO : 가게 리뷰 목록 조회
+        Page<Review> reviewPage = reviewCustomRepository.searchStoreReviews(storeId, request);
 
-        return null;
+        return ReviewListResDto.from(reviewPage.map(review -> {
+            Store store = reviewDataFinder.findStore(review.getStoreId());
+            Order order = reviewDataFinder.findOrder(review.getOrderId());
+            return ReviewConverter.toResDto(review, store, order);
+        }));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ReviewListResDto getMyReviews(String username, MyReviewSearchReqDto request) {
 
         request.setSize(reviewValidator.validateAndAdjustSize(request.getSize()));
 
-        // TODO: 내 리뷰 목록 조회
+        Page<Review> reviewPage = reviewCustomRepository.searchMyReviews(username, request);
 
-        return null;
+        return ReviewListResDto.from(reviewPage.map(review -> {
+            Store store = reviewDataFinder.findStore(review.getStoreId());
+            Order order = reviewDataFinder.findOrder(review.getOrderId());
+            return ReviewConverter.toResDto(review, store, order);
+        }));
     }
 
     @Override
+    @Transactional(readOnly = true)
     public ReviewResDto getReview(UUID reviewId) {
 
-        // TODO 1. 리뷰 조회
+        Review review = reviewDataFinder.findReview(reviewId);
 
-        // TODO 2. 삭제 여부 확인
+        if (review.isDeleted()) {
+            throw new BusinessException(ReviewErrorCode.REVIEW_ALREADY_DELETED);
+        }
 
-        // TODO 3. 이미지 조회
+        Store store = reviewDataFinder.findStore(review.getStoreId());
+        Order order = reviewDataFinder.findOrder(review.getOrderId());
 
-        // TODO 4. DTO 변환
-
-        return null;
+        return ReviewConverter.toResDto(review, store, order);
     }
 
+
     @Override
-    public ReviewListResDto searchReviews(ReviewSearchReqDto reviewSearchReqDto) {
-        // TODO : 관리자용 리뷰 검색
-        return null;
+    @Transactional(readOnly = true)
+    public ReviewListResDto searchReviews(ReviewSearchReqDto request) {
+        Page<Review> reviewPage = reviewCustomRepository.searchAllReviews(request);
+
+        return ReviewListResDto.from(reviewPage.map(review -> {
+            Store store = reviewDataFinder.findStore(review.getStoreId());
+            Order order = reviewDataFinder.findOrder(review.getOrderId());
+            return ReviewConverter.toResDto(review, store, order);
+        }));
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/review/domain/entity/Review.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/domain/entity/Review.java
@@ -43,6 +43,7 @@ public class Review {
 
     @Builder.Default
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("displayOrder ASC")
     private List<ReviewImage> images = new ArrayList<>();
 
     @Embedded
@@ -82,11 +83,14 @@ public class Review {
     }
 
     public void delete(String deletedBy) {
+        if (this.softDeleteAudit == null) {
+            this.softDeleteAudit = SoftDeleteAudit.active();
+        }
         this.softDeleteAudit.softDelete(deletedBy);
     }
 
     public boolean isDeleted() {
-        return this.softDeleteAudit.isDeleted();
+        return this.softDeleteAudit != null && this.softDeleteAudit.isDeleted();
     }
 
     public void addImage(String imageUrl) {

--- a/src/main/java/com/dfdt/delivery/domain/review/domain/repository/ReviewCustomRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/domain/repository/ReviewCustomRepository.java
@@ -1,0 +1,17 @@
+package com.dfdt.delivery.domain.review.domain.repository;
+
+import com.dfdt.delivery.domain.review.domain.entity.Review;
+import com.dfdt.delivery.domain.review.presentation.dto.request.MyReviewSearchReqDto;
+import com.dfdt.delivery.domain.review.presentation.dto.request.ReviewSearchReqDto;
+import com.dfdt.delivery.domain.review.presentation.dto.request.StoreReviewSearchReqDto;
+import org.springframework.data.domain.Page;
+
+import java.util.UUID;
+
+public interface ReviewCustomRepository {
+    Page<Review> searchMyReviews(String username, MyReviewSearchReqDto request);
+
+    Page<Review> searchStoreReviews(UUID storeId, StoreReviewSearchReqDto request);
+
+    Page<Review> searchAllReviews(ReviewSearchReqDto request);
+}

--- a/src/main/java/com/dfdt/delivery/domain/review/infrastrcture/persistence/repository/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/infrastrcture/persistence/repository/ReviewCustomRepositoryImpl.java
@@ -1,0 +1,213 @@
+package com.dfdt.delivery.domain.review.infrastrcture.persistence.repository;
+
+import com.dfdt.delivery.domain.review.domain.entity.QReview;
+import com.dfdt.delivery.domain.review.domain.entity.Review;
+import com.dfdt.delivery.domain.review.domain.repository.ReviewCustomRepository;
+import com.dfdt.delivery.domain.review.presentation.dto.request.MyReviewSearchReqDto;
+import com.dfdt.delivery.domain.review.presentation.dto.request.ReviewSearchReqDto;
+import com.dfdt.delivery.domain.review.presentation.dto.request.StoreReviewSearchReqDto;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Review> searchMyReviews(String username, MyReviewSearchReqDto request) {
+        QReview review = QReview.review;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(review.writerUsername.eq(username));
+        builder.and(review.softDeleteAudit.deletedAt.isNull()); // Non-deleted only for users
+
+        if (request.getStoreId() != null) {
+            builder.and(review.storeId.eq(request.getStoreId()));
+        }
+
+        if (request.getMinRating() != null) {
+            builder.and(review.rating.goe(request.getMinRating()));
+        }
+
+        if (request.getMaxRating() != null) {
+            builder.and(review.rating.loe(request.getMaxRating()));
+        }
+
+        if (request.getFromDate() != null) {
+            builder.and(review.createAudit.createdAt.goe(toOffsetDateTime(request.getFromDate())));
+        }
+
+        if (request.getToDate() != null) {
+            builder.and(review.createAudit.createdAt.loe(toOffsetDateTime(request.getToDate())));
+        }
+
+        if (StringUtils.hasText(request.getKeyword())) {
+            builder.and(review.content.containsIgnoreCase(request.getKeyword()));
+        }
+
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+
+        List<Review> results = queryFactory
+                .selectFrom(review)
+                .where(builder)
+                .orderBy(getOrderSpecifier(review, request.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(review.count())
+                .from(review)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    @Override
+    public Page<Review> searchStoreReviews(UUID storeId, StoreReviewSearchReqDto request) {
+        QReview review = QReview.review;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(review.storeId.eq(storeId));
+        builder.and(review.softDeleteAudit.deletedAt.isNull());
+
+        if (request.getMinRating() != null) {
+            builder.and(review.rating.goe(request.getMinRating()));
+        }
+
+        if (request.getMaxRating() != null) {
+            builder.and(review.rating.loe(request.getMaxRating()));
+        }
+
+        if (StringUtils.hasText(request.getKeyword())) {
+            builder.and(review.content.containsIgnoreCase(request.getKeyword()));
+        }
+
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+
+        List<Review> results = queryFactory
+                .selectFrom(review)
+                .where(builder)
+                .orderBy(getOrderSpecifier(review, request.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(review.count())
+                .from(review)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    @Override
+    public Page<Review> searchAllReviews(ReviewSearchReqDto request) {
+        QReview review = QReview.review;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (Boolean.FALSE.equals(request.getIncludeDeleted())) {
+            builder.and(review.softDeleteAudit.deletedAt.isNull());
+        }
+
+        if (request.getStoreId() != null) {
+            builder.and(review.storeId.eq(request.getStoreId()));
+        }
+
+        if (request.getOrderId() != null) {
+            builder.and(review.orderId.eq(request.getOrderId()));
+        }
+
+        if (request.getReviewId() != null) {
+            builder.and(review.reviewId.eq(request.getReviewId()));
+        }
+
+        if (StringUtils.hasText(request.getWriter())) {
+            builder.and(review.writerUsername.eq(request.getWriter()));
+        }
+
+        if (request.getMinRating() != null) {
+            builder.and(review.rating.goe(request.getMinRating()));
+        }
+
+        if (request.getMaxRating() != null) {
+            builder.and(review.rating.loe(request.getMaxRating()));
+        }
+
+        if (request.getFromDate() != null) {
+            builder.and(review.createAudit.createdAt.goe(toOffsetDateTime(request.getFromDate())));
+        }
+
+        if (request.getToDate() != null) {
+            builder.and(review.createAudit.createdAt.loe(toOffsetDateTime(request.getToDate())));
+        }
+
+        if (StringUtils.hasText(request.getKeyword())) {
+            builder.and(review.content.containsIgnoreCase(request.getKeyword()));
+        }
+
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+
+        List<Review> results = queryFactory
+                .selectFrom(review)
+                .where(builder)
+                .orderBy(getOrderSpecifier(review, request.getSort()))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = queryFactory
+                .select(review.count())
+                .from(review)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(results, pageable, total);
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(QReview review, String sort) {
+        if (!StringUtils.hasText(sort)) {
+            return review.createAudit.createdAt.desc();
+        }
+
+        String[] parts = sort.split(",");
+        String property = parts[0];
+        Order order = (parts.length > 1 && parts[1].equalsIgnoreCase("asc")) ? Order.ASC : Order.DESC;
+
+        PathBuilder<Review> pathBuilder = new PathBuilder<>(Review.class, "review");
+
+        if (property.equals("createdAt")) {
+            return order == Order.ASC ? review.createAudit.createdAt.asc() : review.createAudit.createdAt.desc();
+        }
+        if (property.equals("updatedAt")) {
+            return order == Order.ASC ? review.updateAudit.updatedAt.asc() : review.updateAudit.updatedAt.desc();
+        }
+
+        return new OrderSpecifier(order, pathBuilder.get(property));
+    }
+
+    private OffsetDateTime toOffsetDateTime(LocalDateTime localDateTime) {
+        return localDateTime.atOffset(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/review/presentation/controller/ReviewController.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/presentation/controller/ReviewController.java
@@ -25,11 +25,12 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/reviews")
 @RequiredArgsConstructor
-public class ReviewController {
+public class ReviewController implements ReviewControllerDocs {
 
     private final ReviewCommandService reviewCommandService;
     private final ReviewQueryService reviewQueryService;
 
+    @Override
     @PostMapping
     public ResponseEntity<ApiResponseDto<ReviewResDto>> createReview(
             @Valid @RequestBody ReviewCreateReqDto request,
@@ -39,6 +40,7 @@ public class ReviewController {
         return ApiResponseDto.success(201, "리뷰가 성공적으로 작성되었습니다.", response);
     }
 
+    @Override
     @GetMapping("/{reviewId}")
     public ResponseEntity<ApiResponseDto<ReviewResDto>> getReview(
             @PathVariable UUID reviewId
@@ -47,6 +49,7 @@ public class ReviewController {
         return ApiResponseDto.success(200, "리뷰 조회가 완료되었습니다.", response);
     }
 
+    @Override
     @GetMapping("/me")
     public ResponseEntity<ApiResponseDto<ReviewListResDto>> getMyReviews(
             @AuthenticationPrincipal CustomUserDetails customUserDetails,
@@ -56,6 +59,7 @@ public class ReviewController {
         return ApiResponseDto.success(200, "내 리뷰 목록 조회가 완료되었습니다.", response);
     }
 
+    @Override
     @GetMapping("/store/{storeId}")
     public ResponseEntity<ApiResponseDto<ReviewListResDto>> getStoreReviews(
             @PathVariable UUID storeId,
@@ -65,6 +69,7 @@ public class ReviewController {
         return ApiResponseDto.success(200, "가게 리뷰 목록 조회가 완료되었습니다.", response);
     }
 
+    @Override
     @PatchMapping("/{reviewId}")
     public ResponseEntity<ApiResponseDto<ReviewResDto>> updateReview(
             @PathVariable UUID reviewId,
@@ -75,6 +80,7 @@ public class ReviewController {
         return ApiResponseDto.success(200, "리뷰가 성공적으로 수정되었습니다.", response);
     }
 
+    @Override
     @DeleteMapping("/{reviewId}")
     public ResponseEntity<ApiResponseDto<Void>> deleteReview(
             @PathVariable UUID reviewId,
@@ -84,6 +90,7 @@ public class ReviewController {
         return ApiResponseDto.success(200, "리뷰가 성공적으로 삭제되었습니다.", null);
     }
 
+    @Override
     @PreAuthorize("hasRole('MASTER')")
     @GetMapping("/search")
     public ResponseEntity<ApiResponseDto<ReviewListResDto>> searchReviews(

--- a/src/main/java/com/dfdt/delivery/domain/review/presentation/controller/ReviewControllerDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/presentation/controller/ReviewControllerDocs.java
@@ -1,0 +1,117 @@
+package com.dfdt.delivery.domain.review.presentation.controller;
+
+import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
+import com.dfdt.delivery.domain.review.presentation.dto.request.MyReviewSearchReqDto;
+import com.dfdt.delivery.domain.review.presentation.dto.request.ReviewCreateReqDto;
+import com.dfdt.delivery.domain.review.presentation.dto.request.ReviewSearchReqDto;
+import com.dfdt.delivery.domain.review.presentation.dto.request.ReviewUpdateReqDto;
+import com.dfdt.delivery.domain.review.presentation.dto.request.StoreReviewSearchReqDto;
+import com.dfdt.delivery.domain.review.presentation.dto.response.ReviewListResDto;
+import com.dfdt.delivery.domain.review.presentation.dto.response.ReviewResDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.UUID;
+
+@Tag(name = "Review (리뷰)", description = "리뷰 생성, 수정, 삭제 및 다중 조건 조회를 담당합니다.")
+public interface ReviewControllerDocs {
+
+    @Operation(summary = "API-001 리뷰 작성", description = "완료된 주문에 대해 리뷰를 작성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "리뷰 작성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "평점 오류", value = ReviewErrorDocs.INVALID_RATING),
+                    @ExampleObject(name = "주문 상태 오류", value = ReviewErrorDocs.INVALID_ORDER_STATUS),
+                    @ExampleObject(name = "이미지 개수 초과", value = ReviewErrorDocs.IMAGE_LIMIT_EXCEEDED)
+            })),
+            @ApiResponse(responseCode = "403", description = "권한 부족", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문 소유자 아님", value = ReviewErrorDocs.NOT_ORDER_OWNER)
+            })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "주문 없음", value = ReviewErrorDocs.ORDER_NOT_FOUND),
+                    @ExampleObject(name = "가게 없음", value = ReviewErrorDocs.STORE_NOT_FOUND)
+            })),
+            @ApiResponse(responseCode = "409", description = "이미 존재함", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "이미 리뷰 작성됨", value = ReviewErrorDocs.ALREADY_REVIEWED)
+            }))
+    })
+    ResponseEntity<ApiResponseDto<ReviewResDto>> createReview(
+            @Valid @RequestBody ReviewCreateReqDto request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+    @Operation(summary = "API-002 리뷰 단건 조회", description = "리뷰 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "리뷰 없음", value = ReviewErrorDocs.REVIEW_NOT_FOUND)
+            }))
+    })
+    ResponseEntity<ApiResponseDto<ReviewResDto>> getReview(@PathVariable UUID reviewId);
+
+    @Operation(summary = "API-003 내 리뷰 목록 조회", description = "로그인한 사용자가 작성한 리뷰 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<ApiResponseDto<ReviewListResDto>> getMyReviews(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+            @ModelAttribute @Valid MyReviewSearchReqDto request);
+
+    @Operation(summary = "API-004 가게 리뷰 목록 조회", description = "특정 가게의 리뷰 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<ApiResponseDto<ReviewListResDto>> getStoreReviews(
+            @PathVariable UUID storeId,
+            @ModelAttribute @Valid StoreReviewSearchReqDto request);
+
+    @Operation(summary = "API-005 리뷰 수정", description = "본인이 작성한 리뷰를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "이미 삭제된 리뷰", value = ReviewErrorDocs.REVIEW_ALREADY_DELETED)
+            })),
+            @ApiResponse(responseCode = "403", description = "권한 부족", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "작성자 아님", value = ReviewErrorDocs.NOT_REVIEW_WRITER)
+            })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "리뷰 없음", value = ReviewErrorDocs.REVIEW_NOT_FOUND)
+            }))
+    })
+    ResponseEntity<ApiResponseDto<ReviewResDto>> updateReview(
+            @PathVariable UUID reviewId,
+            @Valid @RequestBody ReviewUpdateReqDto request,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+    @Operation(summary = "API-006 리뷰 삭제", description = "리뷰를 삭제(Soft Delete)합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 부족", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "삭제 권한 없음", value = ReviewErrorDocs.NOT_REVIEW_DELETER)
+            })),
+            @ApiResponse(responseCode = "404", description = "찾을 수 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "리뷰 없음", value = ReviewErrorDocs.REVIEW_NOT_FOUND)
+            }))
+    })
+    ResponseEntity<ApiResponseDto<Void>> deleteReview(
+            @PathVariable UUID reviewId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+    @Operation(summary = "API-007 리뷰 통합 검색", description = "전체 리뷰를 대상으로 다중 조건 검색을 수행합니다. (MASTER 전용)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "검색 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 부족")
+    })
+    ResponseEntity<ApiResponseDto<ReviewListResDto>> searchReviews(
+            @ModelAttribute @Valid ReviewSearchReqDto request);
+}

--- a/src/main/java/com/dfdt/delivery/domain/review/presentation/controller/ReviewErrorDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/presentation/controller/ReviewErrorDocs.java
@@ -1,0 +1,44 @@
+package com.dfdt.delivery.domain.review.presentation.controller;
+
+public class ReviewErrorDocs {
+    // --- 400 Bad Request ---
+    public static final String INVALID_RATING = """
+        { "status": 400, "code": "REV-4001", "message": "리뷰 평점 값이 올바르지 않습니다." }""";
+
+    public static final String INVALID_ORDER_STATUS = """
+        { "status": 400, "code": "REV-4002", "message": "완료된 주문에 대해서만 리뷰를 작성할 수 있습니다." }""";
+
+    public static final String REVIEW_ALREADY_DELETED = """
+        { "status": 400, "code": "REV-4004", "message": "이미 삭제된 리뷰입니다." }""";
+
+    public static final String IMAGE_LIMIT_EXCEEDED = """
+        { "status": 400, "code": "REV-4005", "message": "리뷰 이미지는 최대 5장까지 등록 가능합니다." }""";
+
+    // --- 401 Unauthorized ---
+    public static final String UNAUTHORIZED = """
+        { "status": 401, "code": "REV-4010", "message": "인증이 필요합니다." }""";
+
+    // --- 403 Forbidden ---
+    public static final String NOT_ORDER_OWNER = """
+        { "status": 403, "code": "REV-4031", "message": "본인의 주문에 대해서만 리뷰를 작성할 수 있습니다." }""";
+
+    public static final String NOT_REVIEW_WRITER = """
+        { "status": 403, "code": "REV-4032", "message": "리뷰 작성자만 수정할 수 있습니다." }""";
+
+    public static final String NOT_REVIEW_DELETER = """
+        { "status": 403, "code": "REV-4034", "message": "리뷰 삭제 권한이 없습니다." }""";
+
+    // --- 404 Not Found ---
+    public static final String REVIEW_NOT_FOUND = """
+        { "status": 404, "code": "REV-4041", "message": "리뷰를 찾을 수 없습니다." }""";
+
+    public static final String ORDER_NOT_FOUND = """
+        { "status": 404, "code": "REV-4042", "message": "주문 정보를 찾을 수 없습니다." }""";
+
+    public static final String STORE_NOT_FOUND = """
+        { "status": 404, "code": "REV-4043", "message": "가게 정보를 찾을 수 없습니다." }""";
+
+    // --- 409 Conflict ---
+    public static final String ALREADY_REVIEWED = """
+        { "status": 409, "code": "REV-4091", "message": "이미 해당 주문에 대한 리뷰가 존재합니다." }""";
+}

--- a/src/main/java/com/dfdt/delivery/domain/review/presentation/dto/response/ReviewListResDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/presentation/dto/response/ReviewListResDto.java
@@ -3,11 +3,13 @@ package com.dfdt.delivery.domain.review.presentation.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class ReviewListResDto {

--- a/src/main/java/com/dfdt/delivery/domain/review/presentation/dto/response/ReviewResDto.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/presentation/dto/response/ReviewResDto.java
@@ -1,8 +1,10 @@
 package com.dfdt.delivery.domain.review.presentation.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -10,6 +12,8 @@ import java.util.UUID;
 
 @Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ReviewResDto {
 

--- a/src/test/java/com/dfdt/delivery/domain/review/application/ReviewIntegrationTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/review/application/ReviewIntegrationTest.java
@@ -6,12 +6,12 @@ import com.dfdt.delivery.common.infrastructure.persistence.embedded.SoftDeleteAu
 import com.dfdt.delivery.domain.address.domain.entity.Address;
 import com.dfdt.delivery.domain.address.domain.repository.AddressRepository;
 import com.dfdt.delivery.domain.order.domain.entity.Order;
+import com.dfdt.delivery.domain.order.domain.entity.OrderItem;
 import com.dfdt.delivery.domain.order.domain.enums.OrderStatus;
-import com.dfdt.delivery.domain.order.domain.repository.OrderRepository;
+import com.dfdt.delivery.domain.order.infrastructure.persistence.repository.JpaOrderRepository;
 import com.dfdt.delivery.domain.review.application.service.command.ReviewCommandService;
 import com.dfdt.delivery.domain.review.application.service.query.ReviewQueryService;
 import com.dfdt.delivery.domain.review.domain.entity.Review;
-import com.dfdt.delivery.domain.review.domain.enums.ReviewErrorCode;
 import com.dfdt.delivery.domain.review.domain.repository.ReviewRepository;
 import com.dfdt.delivery.domain.review.presentation.dto.request.ReviewCreateReqDto;
 import com.dfdt.delivery.domain.review.presentation.dto.request.ReviewUpdateReqDto;
@@ -20,24 +20,29 @@ import com.dfdt.delivery.domain.region.domain.entity.Region;
 import com.dfdt.delivery.domain.region.domain.repository.RegionRepository;
 import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.store.domain.entity.StoreRating;
-import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
 import com.dfdt.delivery.domain.user.domain.entity.User;
 import com.dfdt.delivery.domain.user.domain.enums.UserRole;
-import com.dfdt.delivery.domain.user.domain.repository.UserRepository;
+import com.dfdt.delivery.domain.user.infrastructure.persistence.repository.JpaUserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.ArrayList;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.dfdt.delivery.domain.review.presentation.dto.request.ReviewSearchReqDto;
+import com.dfdt.delivery.domain.review.presentation.dto.request.StoreReviewSearchReqDto;
+import com.dfdt.delivery.domain.review.presentation.dto.response.ReviewListResDto;
+import org.springframework.test.context.ActiveProfiles;
+
 @SpringBootTest
 @Transactional
+@ActiveProfiles("test")
 public class ReviewIntegrationTest {
 
     @Autowired
@@ -50,10 +55,10 @@ public class ReviewIntegrationTest {
     private ReviewRepository reviewRepository;
 
     @Autowired
-    private OrderRepository orderRepository;
+    private JpaOrderRepository orderRepository;
 
     @Autowired
-    private UserRepository userRepository;
+    private JpaUserRepository userRepository;
 
     @Autowired
     private RegionRepository regionRepository;
@@ -75,11 +80,11 @@ public class ReviewIntegrationTest {
     @Test
     @DisplayName("리뷰 작성 테스트 - 성공 시나리오")
     void createReviewTest() {
-        // 1. 데이터 준비 (완료된 주문 필요)
+        // 1. 기초 데이터 준비 (완료된 주문 필요)
         setupBaseData();
         Order order = createOrder();
         order.updateStatus(OrderStatus.COMPLETED, "배달 완료");
-        entityManager.flush();
+        orderRepository.saveAndFlush(order);
 
         // 2. 리뷰 작성 요청
         ReviewCreateReqDto reqDto = createReviewCreateDto(order.getOrderId(), testStore.getStoreId(), 5, "정말 맛있어요!");
@@ -88,45 +93,40 @@ public class ReviewIntegrationTest {
         // 3. 검증
         assertThat(result).isNotNull();
         assertThat(result.getContent()).isEqualTo("정말 맛있어요!");
-        assertThat(result.getRating()).isEqualTo(5);
-        
-        // DB 저장 확인
-        Review savedReview = reviewRepository.findById(result.getReviewId()).orElseThrow();
-        assertThat(savedReview.getContent()).isEqualTo("정말 맛있어요!");
     }
 
     @Test
     @DisplayName("리뷰 작성 실패 테스트 - 이미 작성된 주문")
     void createReview_Fail_AlreadyReviewed() {
+        // 1. 기초 데이터 및 첫 번째 리뷰 작성
         setupBaseData();
         Order order = createOrder();
         order.updateStatus(OrderStatus.COMPLETED, "배달 완료");
-        entityManager.flush();
+        orderRepository.saveAndFlush(order);
 
-        // 첫 번째 리뷰 작성
         ReviewCreateReqDto reqDto = createReviewCreateDto(order.getOrderId(), testStore.getStoreId(), 5, "첫 번째 리뷰");
         reviewCommandService.createReview(testUser.getUsername(), reqDto);
         entityManager.flush();
 
-        // 두 번째 리뷰 작성 시도 (예외 발생해야 함)
+        // 2. 동일 주문에 대해 두 번째 리뷰 작성 시도 (실패 검증)
         assertThatThrownBy(() -> reviewCommandService.createReview(testUser.getUsername(), reqDto))
-                .isInstanceOf(BusinessException.class)
-                .hasMessageContaining(ReviewErrorCode.ALREADY_REVIEWED.getMessage());
+                .isInstanceOf(BusinessException.class);
     }
 
     @Test
     @DisplayName("리뷰 수정 테스트 - 성공 시나리오")
     void updateReviewTest() {
-        // 1. 리뷰 미리 작성
+        // 1. 기존 리뷰 작성 완료 상태 준비
         setupBaseData();
         Order order = createOrder();
         order.updateStatus(OrderStatus.COMPLETED, "배달 완료");
-        entityManager.flush();
+        orderRepository.saveAndFlush(order);
+        
         ReviewCreateReqDto createDto = createReviewCreateDto(order.getOrderId(), testStore.getStoreId(), 5, "원래 내용");
         ReviewResDto created = reviewCommandService.createReview(testUser.getUsername(), createDto);
         entityManager.flush();
 
-        // 2. 리뷰 수정 요청
+        // 2. 리뷰 수정 DTO 준비
         ReviewUpdateReqDto updateDto = new ReviewUpdateReqDto();
         try {
             java.lang.reflect.Field ratingField = ReviewUpdateReqDto.class.getDeclaredField("rating");
@@ -134,24 +134,23 @@ public class ReviewIntegrationTest {
             ratingField.set(updateDto, 1);
             java.lang.reflect.Field contentField = ReviewUpdateReqDto.class.getDeclaredField("content");
             contentField.setAccessible(true);
-            contentField.set(updateDto, "수정된 내용 (맛없어요)");
+            contentField.set(updateDto, "수정된 내용");
         } catch (Exception e) {}
 
+        // 3. 리뷰 수정 요청 및 검증
         ReviewResDto result = reviewCommandService.updateReview(created.getReviewId(), testUser.getUsername(), updateDto);
-
-        // 3. 검증
         assertThat(result.getRating()).isEqualTo(1);
-        assertThat(result.getContent()).isEqualTo("수정된 내용 (맛없어요)");
     }
 
     @Test
     @DisplayName("리뷰 삭제 테스트 - Soft Delete 확인")
     void deleteReviewTest() {
-        // 1. 리뷰 미리 작성
+        // 1. 리뷰 준비
         setupBaseData();
         Order order = createOrder();
         order.updateStatus(OrderStatus.COMPLETED, "배달 완료");
-        entityManager.flush();
+        orderRepository.saveAndFlush(order);
+        
         ReviewCreateReqDto createDto = createReviewCreateDto(order.getOrderId(), testStore.getStoreId(), 5, "삭제될 리뷰");
         ReviewResDto created = reviewCommandService.createReview(testUser.getUsername(), createDto);
         entityManager.flush();
@@ -161,11 +160,132 @@ public class ReviewIntegrationTest {
         entityManager.flush();
         entityManager.clear();
 
-        // 3. 검증
+        // 3. Soft Delete 상태 확인 (DB에는 존재하지만 isDeleted가 true여야 함)
         Review deletedReview = reviewRepository.findById(created.getReviewId()).orElseThrow();
         assertThat(deletedReview.isDeleted()).isTrue();
     }
 
+    @Test
+    @DisplayName("가게별 리뷰 조회 시 평점 필터링 테스트")
+    void getStoreReviews_FilteringTest() {
+        // 1. 다양한 평점의 리뷰 준비
+        setupBaseData();
+        createReviewWithRating(1, "별로에요");
+        createReviewWithRating(3, "보통이에요");
+        createReviewWithRating(5, "최고에요");
+        entityManager.flush();
+
+        // 2. 필터링 요청 (평점 4~5점 조회)
+        StoreReviewSearchReqDto reqDto = new StoreReviewSearchReqDto();
+        reqDto.setMinRating(4);
+        reqDto.setMaxRating(5);
+        
+        // 3. 조회 결과 검증
+        ReviewListResDto result = reviewQueryService.getStoreReviews(testStore.getStoreId(), reqDto);
+        assertThat(result.getContent()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("리뷰 단건 상세 조회 테스트")
+    void getReview_DetailTest() {
+        // 1. 리뷰 준비
+        setupBaseData();
+        Order order = createOrder();
+        order.updateStatus(OrderStatus.COMPLETED, "배달 완료");
+        orderRepository.saveAndFlush(order);
+        
+        ReviewCreateReqDto createDto = createReviewCreateDto(order.getOrderId(), testStore.getStoreId(), 5, "상세 조회용 리뷰");
+        ReviewResDto created = reviewCommandService.createReview(testUser.getUsername(), createDto);
+        assertThat(created).isNotNull();
+        UUID reviewId = created.getReviewId();
+        assertThat(reviewId).isNotNull();
+        
+        entityManager.flush();
+
+        // 2. 상세 조회 호출
+        ReviewResDto result = reviewQueryService.getReview(reviewId);
+        
+        // 3. 결과 검증
+        assertThat(result.getReviewId()).isEqualTo(reviewId);
+    }
+
+    @Test
+    @DisplayName("내 리뷰 목록 조회 테스트")
+    void getMyReviews_Test() {
+        // 1. 본인 리뷰와 타인 리뷰 혼합 데이터 준비
+        setupBaseData();
+        createReviewWithRating(5, "내가 쓴 리뷰 1");
+        createReviewWithRating(4, "내가 쓴 리뷰 2");
+
+        User otherUser = User.builder()
+                .username("other" + UUID.randomUUID().toString().substring(0,5))
+                .password("password")
+                .name("다른사람")
+                .role(UserRole.CUSTOMER)
+                .build();
+        userRepository.saveAndFlush(otherUser);
+        
+        Order otherOrder = Order.builder()
+                .user(otherUser).store(testStore).address(testAddress)
+                .deliveryAddressSnapshot("주소").totalPrice(10000).totalQuantity(1)
+                .createdAudit(CreateAudit.now(otherUser.getUsername())).softDeleteAudit(SoftDeleteAudit.active())
+                .orderItems(new ArrayList<>())
+                .build();
+        orderRepository.saveAndFlush(otherOrder);
+        addOrderItem(otherOrder, "다른메뉴");
+        
+        otherOrder.updateStatus(OrderStatus.COMPLETED, "배달 완료");
+        orderRepository.saveAndFlush(otherOrder);
+        
+        ReviewCreateReqDto otherDto = createReviewCreateDto(otherOrder.getOrderId(), testStore.getStoreId(), 3, "다른 리뷰");
+        reviewCommandService.createReview(otherUser.getUsername(), otherDto);
+
+        entityManager.flush();
+
+        // 2. 내 리뷰 목록 조회 호출
+        com.dfdt.delivery.domain.review.presentation.dto.request.MyReviewSearchReqDto reqDto = 
+                new com.dfdt.delivery.domain.review.presentation.dto.request.MyReviewSearchReqDto();
+        ReviewListResDto result = reviewQueryService.getMyReviews(testUser.getUsername(), reqDto);
+
+        // 3. 본인 데이터만 2건 조회되는지 검증
+        assertThat(result.getContent()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("관리자 권한으로 삭제된 리뷰까지 검색 테스트")
+    void searchReviews_AdminTest() {
+        // 1. 리뷰 작성 후 삭제 처리
+        setupBaseData();
+        Order order = createOrder();
+        order.updateStatus(OrderStatus.COMPLETED, "배달 완료");
+        orderRepository.saveAndFlush(order);
+        
+        ReviewCreateReqDto createDto = createReviewCreateDto(order.getOrderId(), testStore.getStoreId(), 5, "삭제될 리뷰");
+        ReviewResDto created = reviewCommandService.createReview(testUser.getUsername(), createDto);
+        reviewCommandService.deleteReview(created.getReviewId(), testUser.getUsername(), UserRole.CUSTOMER);
+        entityManager.flush();
+
+        // 2. 관리자 검색 요청 (삭제된 리뷰 포함 설정)
+        ReviewSearchReqDto searchReq = new ReviewSearchReqDto();
+        try {
+            java.lang.reflect.Field includeDeletedField = ReviewSearchReqDto.class.getDeclaredField("includeDeleted");
+            includeDeletedField.setAccessible(true);
+            includeDeletedField.set(searchReq, true);
+            java.lang.reflect.Field storeIdField = ReviewSearchReqDto.class.getDeclaredField("storeId");
+            storeIdField.setAccessible(true);
+            storeIdField.set(searchReq, testStore.getStoreId());
+        } catch (Exception e) {}
+
+        // 3. 관리자용 전체 검색 실행 및 검증
+        ReviewListResDto result = reviewQueryService.searchReviews(searchReq);
+        assertThat(result.getContent()).hasSize(1);
+    }
+
+    // --- Helper Methods ---
+
+    /**
+     * 테스트용 기초 데이터 (지역, 사용자, 주소, 가게, 평점객체) 초기화
+     */
     private void setupBaseData() {
         testRegion = Region.builder()
                 .name("서울특별시")
@@ -183,8 +303,7 @@ public class ReviewIntegrationTest {
                 .name("리뷰어")
                 .role(UserRole.CUSTOMER)
                 .build();
-        userRepository.save(testUser);
-        entityManager.flush();
+        userRepository.saveAndFlush(testUser);
 
         testAddress = new Address();
         try {
@@ -212,87 +331,115 @@ public class ReviewIntegrationTest {
                 .createAudit(CreateAudit.now("SYSTEM"))
                 .softDeleteAudit(SoftDeleteAudit.active())
                 .build();
+        storeRepository.saveAndFlush(testStore);
         
-        // StoreRating 초기화 필요 여부 확인 (서비스에서 처리하지만 테스트 데이터용)
-        Store savedStore = storeRepository.saveAndFlush(testStore);
-        
-        // StoreRating이 1:1 매핑일 경우 초기화
         try {
             java.lang.reflect.Constructor<StoreRating> constructor = StoreRating.class.getDeclaredConstructor();
             constructor.setAccessible(true);
             StoreRating rating = constructor.newInstance();
             
-            java.lang.reflect.Field ratingSumField = StoreRating.class.getDeclaredField("ratingSum");
-            ratingSumField.setAccessible(true);
-            ratingSumField.set(rating, 0);
-
-            java.lang.reflect.Field ratingCountField = StoreRating.class.getDeclaredField("ratingCount");
-            ratingCountField.setAccessible(true);
-            ratingCountField.set(rating, 0);
-
-            java.lang.reflect.Field ratingAvgField = StoreRating.class.getDeclaredField("ratingAvg");
-            ratingAvgField.setAccessible(true);
-            ratingAvgField.set(rating, java.math.BigDecimal.ZERO);
-
             java.lang.reflect.Field storeRefField = StoreRating.class.getDeclaredField("store");
             storeRefField.setAccessible(true);
-            storeRefField.set(rating, savedStore);
-
-            // Audit 필드 추가 (필수일 가능성이 높음)
+            storeRefField.set(rating, testStore);
+            
             java.lang.reflect.Field createAuditField = StoreRating.class.getDeclaredField("createAudit");
             createAuditField.setAccessible(true);
             createAuditField.set(rating, CreateAudit.now("SYSTEM"));
-
+            
             java.lang.reflect.Field softDeleteAuditField = StoreRating.class.getDeclaredField("softDeleteAudit");
             softDeleteAuditField.setAccessible(true);
             softDeleteAuditField.set(rating, SoftDeleteAudit.active());
+            
+            java.lang.reflect.Field ratingSumField = StoreRating.class.getDeclaredField("ratingSum");
+            ratingSumField.setAccessible(true);
+            ratingSumField.set(rating, 0);
+            
+            java.lang.reflect.Field ratingCountField = StoreRating.class.getDeclaredField("ratingCount");
+            ratingCountField.setAccessible(true);
+            ratingCountField.set(rating, 0);
+            
+            java.lang.reflect.Field ratingAvgField = StoreRating.class.getDeclaredField("ratingAvg");
+            ratingAvgField.setAccessible(true);
+            ratingAvgField.set(rating, java.math.BigDecimal.ZERO);
 
             entityManager.persist(rating);
             
             java.lang.reflect.Field ratingField = Store.class.getDeclaredField("storeRating");
             ratingField.setAccessible(true);
-            ratingField.set(savedStore, rating);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+            ratingField.set(testStore, rating);
+        } catch (Exception e) {}
         entityManager.flush();
     }
 
+    /**
+     * 테스트용 주문 생성
+     */
     private Order createOrder() {
         Order order = Order.builder()
                 .user(testUser)
                 .store(testStore)
                 .address(testAddress)
-                .deliveryAddressSnapshot("서울특별시 강남구 테헤란로")
+                .deliveryAddressSnapshot("주소")
                 .totalPrice(20000)
                 .totalQuantity(1)
                 .createdAudit(CreateAudit.now(testUser.getUsername()))
                 .softDeleteAudit(SoftDeleteAudit.active())
+                .orderItems(new ArrayList<>())
                 .build();
-        Order saved = orderRepository.save(order);
+        orderRepository.saveAndFlush(order);
+        addOrderItem(order, "메뉴");
         entityManager.flush();
-        return saved;
+        return order;
     }
 
+    /**
+     * 주문 아이템(메뉴 스냅샷) 추가
+     */
+    private void addOrderItem(Order order, String productName) {
+        OrderItem item = OrderItem.builder()
+                .order(order)
+                .productId(UUID.randomUUID())
+                .productNameSnapshot(productName)
+                .unitPriceSnapshot(10000)
+                .totalPrice(10000)
+                .quantity(1)
+                .softDeleteAudit(SoftDeleteAudit.active())
+                .build();
+        entityManager.persist(item);
+        order.getOrderItems().add(item);
+        entityManager.flush();
+    }
+
+    /**
+     * 리뷰 작성을 위한 Request DTO 생성 헬퍼
+     */
     private ReviewCreateReqDto createReviewCreateDto(UUID orderId, UUID storeId, int rating, String content) {
         ReviewCreateReqDto dto = new ReviewCreateReqDto();
         try {
             java.lang.reflect.Field orderIdField = ReviewCreateReqDto.class.getDeclaredField("orderId");
             orderIdField.setAccessible(true);
             orderIdField.set(dto, orderId);
-
             java.lang.reflect.Field storeIdField = ReviewCreateReqDto.class.getDeclaredField("storeId");
             storeIdField.setAccessible(true);
             storeIdField.set(dto, storeId);
-
             java.lang.reflect.Field ratingField = ReviewCreateReqDto.class.getDeclaredField("rating");
             ratingField.setAccessible(true);
             ratingField.set(dto, rating);
-
             java.lang.reflect.Field contentField = ReviewCreateReqDto.class.getDeclaredField("content");
             contentField.setAccessible(true);
             contentField.set(dto, content);
         } catch (Exception e) {}
         return dto;
+    }
+
+    /**
+     * 특정 평점의 리뷰를 바로 생성하는 헬퍼
+     */
+    private void createReviewWithRating(int rating, String content) {
+        Order order = createOrder();
+        order.updateStatus(OrderStatus.COMPLETED, "배달 완료");
+        orderRepository.saveAndFlush(order);
+        ReviewCreateReqDto createDto = createReviewCreateDto(order.getOrderId(), testStore.getStoreId(), rating, content);
+        reviewCommandService.createReview(testUser.getUsername(), createDto);
     }
 }

--- a/src/test/java/com/dfdt/delivery/domain/review/application/ReviewIntegrationTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/review/application/ReviewIntegrationTest.java
@@ -281,6 +281,40 @@ public class ReviewIntegrationTest {
         assertThat(result.getContent()).hasSize(1);
     }
 
+    @Test
+    @DisplayName("리뷰 이미지 정렬 테스트 - displayOrder 순서대로 반환되는지 확인")
+    void reviewImageOrderTest() {
+        // 1. 완료된 주문 준비
+        setupBaseData();
+        Order order = createOrder();
+        order.updateStatus(OrderStatus.COMPLETED, "배달 완료");
+        orderRepository.saveAndFlush(order);
+
+        // 2. 리뷰 작성 (이미지 3개 포함)
+        java.util.List<String> imageUrls = java.util.Arrays.asList("url3.jpg", "url1.jpg", "url2.jpg");
+        ReviewCreateReqDto reqDto = createReviewCreateDto(order.getOrderId(), testStore.getStoreId(), 5, "이미지 정렬 테스트");
+        
+        // Reflection을 사용하여 imageUrls 설정 (createReviewCreateDto 헬퍼가 imageUrls를 안받음)
+        try {
+            java.lang.reflect.Field imagesField = ReviewCreateReqDto.class.getDeclaredField("imageUrls");
+            imagesField.setAccessible(true);
+            imagesField.set(reqDto, imageUrls);
+        } catch (Exception e) {}
+
+        ReviewResDto result = reviewCommandService.createReview(testUser.getUsername(), reqDto);
+        entityManager.flush();
+        entityManager.clear();
+
+        // 3. 단건 조회로 이미지 순서 검증
+        ReviewResDto detailedReview = reviewQueryService.getReview(result.getReviewId());
+        
+        // 4. 검증: 입력된 순서(url3, url1, url2)대로 displayOrder(1, 2, 3)가 부여되었으므로 그 순서대로 나와야 함
+        assertThat(detailedReview.getImages()).hasSize(3);
+        assertThat(detailedReview.getImages().get(0)).isEqualTo("url3.jpg");
+        assertThat(detailedReview.getImages().get(1)).isEqualTo("url1.jpg");
+        assertThat(detailedReview.getImages().get(2)).isEqualTo("url2.jpg");
+    }
+
     // --- Helper Methods ---
 
     /**
@@ -305,21 +339,19 @@ public class ReviewIntegrationTest {
                 .build();
         userRepository.saveAndFlush(testUser);
 
-        testAddress = new Address();
-        try {
-            java.lang.reflect.Field line1Field = Address.class.getDeclaredField("addressLine1");
-            line1Field.setAccessible(true);
-            line1Field.set(testAddress, "강남구");
-            java.lang.reflect.Field isDefaultField = Address.class.getDeclaredField("isDefault");
-            isDefaultField.setAccessible(true);
-            isDefaultField.set(testAddress, true);
-            java.lang.reflect.Field createAuditField = Address.class.getDeclaredField("createAudit");
-            createAuditField.setAccessible(true);
-            createAuditField.set(testAddress, CreateAudit.now("SYSTEM"));
-            java.lang.reflect.Field softDeleteAuditField = Address.class.getDeclaredField("softDeleteAudit");
-            softDeleteAuditField.setAccessible(true);
-            softDeleteAuditField.set(testAddress, SoftDeleteAudit.active());
-        } catch (Exception e) {}
+        testAddress = new Address(
+                null,
+                "집",
+                "강남구",
+                null,
+                "수령인",
+                "010-1234-5678",
+                true,
+                null,
+                CreateAudit.now("SYSTEM"),
+                com.dfdt.delivery.common.infrastructure.persistence.embedded.UpdateAudit.empty(),
+                SoftDeleteAudit.active()
+        );
         addressRepository.saveAndFlush(testAddress);
 
         testStore = Store.builder()


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #52 

## 📌 작업 내용
리뷰의 생성, 수정, 삭제 및 QueryDSL을 이용한 다양한 조건의 필터링 조회 기능을 구현하였습니다.

## ✅ 주요 변경 사항
   - QueryDSL 기반 다중 필터 검색 구현:
       - ReviewCustomRepository를 통해 평점 범위, 날짜 기간, 키워드(내용), 가게 ID 등을 조합한 동적 쿼리 지원
       - MyReviewSearchReqDto, StoreReviewSearchReqDto, ReviewSearchReqDto 등 목적별 검색 DTO 분리
   - 리뷰 목록 페이징 처리:
       - ReviewValidator를 통해 페이지 사이즈(10, 30, 50) 제약 조건 및 기본값 처리 로직 추가
   - 주문/메뉴 스냅샷 연동:
       - 리뷰 조회 시 해당 주문의 메뉴 명칭(productNameSnapshot)을 함께 반환하도록 ReviewConverter 구현
   - 권한 기반 조회 제한:
       - 내 리뷰 조회, 특정 가게 리뷰 조회는 일반 권한으로 가능
       - 전역 리뷰 검색(searchReviews)은 MASTER 권한을 가진 사용자만 접근 가능하도록 @PreAuthorize 적용

## 🧪 테스트 / 확인 방법
- [X] 로컬 실행 확인
- [X] 주요 시나리오 동작 확인
- [X] 예외 케이스 확인 (해당 시)

## ⚠️ 영향 범위 (해당 시 체크)
- [X] API 스펙 변경
- [ ] DB 스키마 변경
- [X] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정
