### PR TITLE
feat: 상품 설명 미리보기 적용 (상품 반영)

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/ApplyDescriptionCommand.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/ApplyDescriptionCommand.java
@@ -1,0 +1,17 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+
+import java.util.UUID;
+
+/**
+ * AI 생성 상품 설명 적용 UseCase 입력 커맨드.
+ * Controller → UseCase 방향으로 전달됩니다.
+ */
+public record ApplyDescriptionCommand(
+        UUID storeId,
+        UUID aiLogId,
+        String requestedBy,       // 인증된 사용자 username
+        UserRole requestedByRole  // 소유권 체크에 사용 (OWNER만 storeId 검증)
+) {
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/ApplyDescriptionResult.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/ApplyDescriptionResult.java
@@ -1,0 +1,16 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * AI 생성 상품 설명 적용 UseCase 결과.
+ * UseCase → Controller 방향으로 전달됩니다.
+ */
+public record ApplyDescriptionResult(
+        UUID aiLogId,
+        UUID productId,
+        String appliedDescription,
+        OffsetDateTime appliedAt
+) {
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/ApplyDescriptionUseCase.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/ApplyDescriptionUseCase.java
@@ -1,0 +1,13 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionCommand;
+import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
+
+/**
+ * API-AI-002: AI 생성 상품 설명 적용 UseCase.
+ * 미리보기로 생성된 AI 설명(AiLog)을 실제 Product.description에 반영합니다.
+ */
+public interface ApplyDescriptionUseCase {
+
+    ApplyDescriptionResult execute(ApplyDescriptionCommand command);
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/ApplyDescriptionUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/ApplyDescriptionUseCaseImpl.java
@@ -1,0 +1,76 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionCommand;
+import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
+import com.dfdt.delivery.domain.ai.domain.entity.AiLogEntity;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogRepository;
+import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.product.domain.repository.ProductRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ApplyDescriptionUseCaseImpl implements ApplyDescriptionUseCase {
+
+    private final AiLogRepository aiLogRepository;
+    private final StoreRepository storeRepository;
+    private final ProductRepository productRepository;
+
+    @Override
+    @Transactional
+    public ApplyDescriptionResult execute(ApplyDescriptionCommand command) {
+
+        // 1. AiLog 조회
+        AiLogEntity aiLog = aiLogRepository.findById(command.aiLogId())
+                .orElseThrow(() -> new BusinessException(AiErrorCode.AI_LOG_NOT_FOUND));
+
+        // 2. storeId 일치 검증 (URL 위변조 방지)
+        if (!aiLog.getStoreId().equals(command.storeId())) {
+            throw new BusinessException(AiErrorCode.STORE_NOT_FOUND);
+        }
+
+        // 3. OWNER 권한: 본인 가게인지 소유권 확인
+        if (command.requestedByRole() == UserRole.OWNER) {
+            Store store = storeRepository.findByStoreIdAndNotDeleted(command.storeId())
+                    .orElseThrow(() -> new BusinessException(AiErrorCode.STORE_NOT_FOUND));
+            if (!store.getUser().getUsername().equals(command.requestedBy())) {
+                throw new BusinessException(AiErrorCode.STORE_ACCESS_DENIED);
+            }
+        }
+
+        // 4. 이미 적용된 로그인지 확인
+        if (Boolean.TRUE.equals(aiLog.getIsApplied())) {
+            throw new BusinessException(AiErrorCode.ALREADY_APPLIED);
+        }
+
+        // 5. productId가 없으면 미리보기 전용 로그 → 적용 불가
+        if (aiLog.getProductId() == null) {
+            throw new BusinessException(AiErrorCode.PRODUCT_ID_REQUIRED_FOR_APPLY);
+        }
+
+        // 6. Product 조회
+        Product product = productRepository.findByProductIdAndStoreId(aiLog.getProductId(), command.storeId())
+                .orElseThrow(() -> new BusinessException(AiErrorCode.PRODUCT_NOT_FOUND));
+
+        // 7. 기존 설명 저장 후 AI 설명 적용
+        String previousDescription = product.getDescription();
+        product.applyAiDescription(aiLog.getResponseText(), command.requestedBy());
+
+        // 8. AiLog에 적용 완료 기록
+        aiLog.applyDescription(previousDescription, command.requestedBy());
+
+        return new ApplyDescriptionResult(
+                aiLog.getAiLogId(),
+                aiLog.getProductId(),
+                aiLog.getResponseText(),
+                aiLog.getAppliedAt()
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
@@ -1,10 +1,14 @@
 package com.dfdt.delivery.domain.ai.presentation.controller;
 
 import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionCommand;
+import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionCommand;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionResult;
+import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.presentation.dto.request.GenerateDescriptionRequest;
+import com.dfdt.delivery.domain.ai.presentation.dto.response.ApplyDescriptionResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.GenerateDescriptionResponse;
 import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -23,6 +27,7 @@ import java.util.UUID;
 public class AiDescriptionController {
 
     private final GenerateDescriptionUseCase generateDescriptionUseCase;
+    private final ApplyDescriptionUseCase applyDescriptionUseCase;
 
     /**
      * AI 상품 설명 미리보기 생성 (API-AI-001)
@@ -45,6 +50,32 @@ public class AiDescriptionController {
                 HttpStatus.CREATED.value(),
                 "AI 상품 설명이 생성되었습니다.",
                 GenerateDescriptionResponse.from(result)
+        );
+    }
+
+    /**
+     * AI 생성 상품 설명 적용 (API-AI-002)
+     * PATCH /api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/apply
+     *
+     * - OWNER: 본인 가게만 적용 가능 (UseCase에서 소유권 체크)
+     * - MASTER: 모든 가게 적용 가능
+     */
+    @PatchMapping("/stores/{storeId}/descriptions/{aiLogId}/apply")
+    @PreAuthorize("hasAnyRole('OWNER', 'MASTER')")
+    public ResponseEntity<ApiResponseDto<ApplyDescriptionResponse>> applyDescriptionPreview(
+            @PathVariable UUID storeId,
+            @PathVariable UUID aiLogId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        ApplyDescriptionCommand command = new ApplyDescriptionCommand(
+                storeId, aiLogId, userDetails.getUsername(), userDetails.getRole()
+        );
+        ApplyDescriptionResult result = applyDescriptionUseCase.execute(command);
+
+        return ApiResponseDto.success(
+                HttpStatus.OK.value(),
+                "AI 상품 설명이 적용되었습니다.",
+                ApplyDescriptionResponse.from(result)
         );
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/ApplyDescriptionResponse.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/ApplyDescriptionResponse.java
@@ -1,0 +1,24 @@
+package com.dfdt.delivery.domain.ai.presentation.dto.response;
+
+import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record ApplyDescriptionResponse(
+        UUID aiLogId,
+        UUID productId,
+        String appliedDescription,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+        OffsetDateTime appliedAt
+) {
+    public static ApplyDescriptionResponse from(ApplyDescriptionResult result) {
+        return new ApplyDescriptionResponse(
+                result.aiLogId(),
+                result.productId(),
+                result.appliedDescription(),
+                result.appliedAt()
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/dfdt/delivery/domain/product/domain/entity/Product.java
@@ -83,6 +83,12 @@ public class Product {
         this.softDeleteAudit.softDelete(username);
     }
 
+    public void applyAiDescription(String aiDescription, String username) {
+        this.description = aiDescription;
+        this.isAiDescription = true;
+        makeUpdateAudit(username);
+    }
+
     public void soldOut(String username) {
         makeUpdateAudit(username);
         this.isHidden = !this.isHidden;

--- a/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/ApplyDescriptionUseCaseImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/ApplyDescriptionUseCaseImplTest.java
@@ -1,0 +1,290 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionCommand;
+import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
+import com.dfdt.delivery.domain.ai.domain.entity.AiLogEntity;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogRepository;
+import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.product.domain.repository.ProductRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ApplyDescriptionUseCaseImpl 테스트")
+class ApplyDescriptionUseCaseImplTest {
+
+    @Mock
+    private AiLogRepository aiLogRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private ApplyDescriptionUseCaseImpl sut;
+
+    private UUID storeId;
+    private UUID aiLogId;
+    private UUID productId;
+    private String requestedBy;
+
+    @BeforeEach
+    void setUp() {
+        storeId = UUID.randomUUID();
+        aiLogId = UUID.randomUUID();
+        productId = UUID.randomUUID();
+        requestedBy = "owner123";
+    }
+
+    // ──────────────────────────────────────────────────
+    // 정상 케이스
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("정상 실행")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("OWNER가 본인 가게의 AI 설명을 Product에 적용하면 성공")
+        void ownerAppliesDescription_success() {
+            // given
+            AiLogEntity mockLog = mockAiLog(storeId, productId, false, "바삭한 치킨입니다!");
+            Store mockStore = mockStore(requestedBy);
+            Product mockProduct = mock(Product.class);
+
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+            given(productRepository.findByProductIdAndStoreId(productId, storeId)).willReturn(Optional.of(mockProduct));
+            given(mockLog.getAppliedAt()).willReturn(OffsetDateTime.now());
+
+            ApplyDescriptionCommand command = new ApplyDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER
+            );
+
+            // when
+            ApplyDescriptionResult result = sut.execute(command);
+
+            // then
+            assertThat(result.aiLogId()).isEqualTo(aiLogId);
+            assertThat(result.productId()).isEqualTo(productId);
+            assertThat(result.appliedDescription()).isEqualTo("바삭한 치킨입니다!");
+            then(mockProduct).should().applyAiDescription(eq("바삭한 치킨입니다!"), eq(requestedBy));
+            then(mockLog).should().applyDescription(any(), eq(requestedBy));
+        }
+
+        @Test
+        @DisplayName("MASTER는 소유권 검사 없이 적용 가능")
+        void masterAppliesDescription_skipsOwnershipCheck() {
+            // given
+            AiLogEntity mockLog = mockAiLog(storeId, productId, false, "치킨 설명");
+            Product mockProduct = mock(Product.class);
+
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+            given(productRepository.findByProductIdAndStoreId(productId, storeId)).willReturn(Optional.of(mockProduct));
+            given(mockLog.getAppliedAt()).willReturn(OffsetDateTime.now());
+
+            ApplyDescriptionCommand command = new ApplyDescriptionCommand(
+                    storeId, aiLogId, "masterUser", UserRole.MASTER
+            );
+
+            // when & then (소유권 체크 없이 성공)
+            assertThatCode(() -> sut.execute(command)).doesNotThrowAnyException();
+            then(storeRepository).should(never()).findByStoreIdAndNotDeleted(any());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // AiLog 조회 관련 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AiLog 관련 예외")
+    class AiLogExceptionTests {
+
+        @Test
+        @DisplayName("존재하지 않는 aiLogId → AI_LOG_NOT_FOUND")
+        void shouldThrowWhenAiLogNotFound() {
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.empty());
+
+            ApplyDescriptionCommand command = new ApplyDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER
+            );
+
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.AI_LOG_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("aiLog.storeId가 pathVariable storeId와 불일치 → STORE_NOT_FOUND")
+        void shouldThrowWhenStoreIdMismatch() {
+            UUID differentStoreId = UUID.randomUUID();
+            AiLogEntity mockLog = mockAiLog(differentStoreId, productId, false, "설명");
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+
+            ApplyDescriptionCommand command = new ApplyDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER
+            );
+
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("이미 적용된 AiLog → ALREADY_APPLIED")
+        void shouldThrowWhenAlreadyApplied() {
+            AiLogEntity mockLog = mockAiLog(storeId, productId, true, "설명");
+            Store mockStore = mockStore(requestedBy);
+
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+
+            ApplyDescriptionCommand command = new ApplyDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER
+            );
+
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.ALREADY_APPLIED));
+        }
+
+        @Test
+        @DisplayName("productId가 없는 미리보기 전용 로그 → PRODUCT_ID_REQUIRED_FOR_APPLY")
+        void shouldThrowWhenProductIdMissing() {
+            AiLogEntity mockLog = mockAiLog(storeId, null, false, "설명");
+            Store mockStore = mockStore(requestedBy);
+
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+
+            ApplyDescriptionCommand command = new ApplyDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER
+            );
+
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.PRODUCT_ID_REQUIRED_FOR_APPLY));
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 소유권 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("소유권 예외")
+    class OwnershipExceptionTests {
+
+        @Test
+        @DisplayName("OWNER가 타인 가게 aiLog 적용 시도 → STORE_ACCESS_DENIED")
+        void shouldThrowWhenOwnerAccessesDifferentStore() {
+            AiLogEntity mockLog = mockAiLog(storeId, productId, false, "설명");
+            Store mockStore = mockStore("otherOwner");
+
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+
+            ApplyDescriptionCommand command = new ApplyDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER // owner123 != otherOwner
+            );
+
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_ACCESS_DENIED));
+        }
+
+        @Test
+        @DisplayName("Store가 조회되지 않으면 → STORE_NOT_FOUND")
+        void shouldThrowWhenStoreNotFoundForOwnership() {
+            AiLogEntity mockLog = mockAiLog(storeId, productId, false, "설명");
+
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.empty());
+
+            ApplyDescriptionCommand command = new ApplyDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER
+            );
+
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_NOT_FOUND));
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // Product 관련 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("Product 관련 예외")
+    class ProductExceptionTests {
+
+        @Test
+        @DisplayName("Product가 조회되지 않으면 → PRODUCT_NOT_FOUND")
+        void shouldThrowWhenProductNotFound() {
+            AiLogEntity mockLog = mockAiLog(storeId, productId, false, "설명");
+            Store mockStore = mockStore(requestedBy);
+
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+            given(productRepository.findByProductIdAndStoreId(productId, storeId)).willReturn(Optional.empty());
+
+            ApplyDescriptionCommand command = new ApplyDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER
+            );
+
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.PRODUCT_NOT_FOUND));
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 헬퍼 메서드
+    // ──────────────────────────────────────────────────
+
+    private AiLogEntity mockAiLog(UUID aiLogStoreId, UUID aiLogProductId, boolean isApplied, String responseText) {
+        AiLogEntity mockLog = mock(AiLogEntity.class);
+        lenient().when(mockLog.getAiLogId()).thenReturn(aiLogId);
+        lenient().when(mockLog.getStoreId()).thenReturn(aiLogStoreId);
+        lenient().when(mockLog.getProductId()).thenReturn(aiLogProductId);
+        lenient().when(mockLog.getIsApplied()).thenReturn(isApplied);
+        lenient().when(mockLog.getResponseText()).thenReturn(responseText);
+        return mockLog;
+    }
+
+    private Store mockStore(String ownerUsername) {
+        User mockUser = mock(User.class);
+        lenient().when(mockUser.getUsername()).thenReturn(ownerUsername);
+        Store mockStore = mock(Store.class);
+        lenient().when(mockStore.getUser()).thenReturn(mockUser);
+        return mockStore;
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
@@ -1,7 +1,9 @@
 package com.dfdt.delivery.domain.ai.presentation.controller;
 
 import com.dfdt.delivery.common.config.SecurityConfig;
+import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionResult;
+import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.domain.entity.enums.Tone;
 import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
@@ -21,6 +23,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -28,6 +31,7 @@ import java.util.UUID;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -48,6 +52,9 @@ class AiDescriptionControllerTest {
 
     @MockBean
     private GenerateDescriptionUseCase generateDescriptionUseCase;
+
+    @MockBean
+    private ApplyDescriptionUseCase applyDescriptionUseCase;
 
     @MockBean
     private com.dfdt.delivery.domain.auth.infrastructure.jwt.JwtProvider jwtProvider;
@@ -246,6 +253,79 @@ class AiDescriptionControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestBody)))
                     .andExpect(status().isBadRequest());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // API-AI-002: AI 생성 상품 설명 적용
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AI 생성 상품 설명 적용 (API-AI-002)")
+    class ApplyDescriptionTests {
+
+        private UUID aiLogId;
+        private UUID productId;
+
+        @BeforeEach
+        void setUpApply() {
+            aiLogId = UUID.randomUUID();
+            productId = UUID.randomUUID();
+        }
+
+        @Test
+        @DisplayName("OWNER가 유효한 요청을 보내면 200과 적용 결과를 반환한다")
+        void ownerShouldReturn200WithApplyResult() throws Exception {
+            // given
+            ApplyDescriptionResult mockResult = new ApplyDescriptionResult(
+                    aiLogId, productId, "바삭한 치킨입니다!", OffsetDateTime.now()
+            );
+            given(applyDescriptionUseCase.execute(any())).willReturn(mockResult);
+
+            // when & then
+            mockMvc.perform(patch("/api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/apply",
+                            storeId, aiLogId)
+                            .with(user(ownerDetails)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.aiLogId").value(aiLogId.toString()))
+                    .andExpect(jsonPath("$.data.productId").value(productId.toString()))
+                    .andExpect(jsonPath("$.data.appliedDescription").value("바삭한 치킨입니다!"));
+        }
+
+        @Test
+        @DisplayName("MASTER도 200을 반환한다")
+        void masterShouldReturn200() throws Exception {
+            // given
+            given(applyDescriptionUseCase.execute(any())).willReturn(
+                    new ApplyDescriptionResult(aiLogId, productId, "치킨 맛있어요!", OffsetDateTime.now())
+            );
+
+            // when & then
+            mockMvc.perform(patch("/api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/apply",
+                            storeId, aiLogId)
+                            .with(user(masterDetails)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 요청은 4xx를 반환한다")
+        void unauthenticatedShouldReturn4xx() throws Exception {
+            mockMvc.perform(patch("/api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/apply",
+                            storeId, aiLogId))
+                    .andExpect(status().is4xxClientError());
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 역할은 403을 반환한다")
+        void customerShouldReturn403() throws Exception {
+            User customer = User.builder()
+                    .username("customer1").name("고객").password("pw").role(UserRole.CUSTOMER).build();
+            CustomUserDetails customerDetails = new CustomUserDetails(customer);
+
+            mockMvc.perform(patch("/api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/apply",
+                            storeId, aiLogId)
+                            .with(user(customerDetails)))
+                    .andExpect(status().isForbidden());
         }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

## 📌 작업 내용
이 PR에서 무엇을 변경했는지 간단히 작성합니다.

## ✅ 주요 변경 사항


레이어 | 파일
-- | --
Application | ApplyDescriptionCommand, ApplyDescriptionResult, ApplyDescriptionUseCase, ApplyDescriptionUseCaseImpl |  
Presentation | AiDescriptionController (엔드포인트 추가), ApplyDescriptionResponse |  
Domain | Product.applyAiDescription() 메서드 추가
Test | ApplyDescriptionUseCaseImplTest (9개), AiDescriptionControllerTest (4개 추가) |  

  비즈니스 로직 흐름

  1. aiLogId로 AiLog 조회 → 없으면 AI_LOG_NOT_FOUND (404)
  2. aiLog.storeId == pathVariable storeId 검증 → 불일치 시
  STORE_NOT_FOUND (404)
  3. OWNER 역할이면 Store 소유권 확인 → STORE_ACCESS_DENIED (403)
  4. isApplied=true이면 → ALREADY_APPLIED (409)
  5. productId=null이면 → PRODUCT_ID_REQUIRED_FOR_APPLY (409)
  6. Product 조회 → 기존 description 저장 후 AI 설명으로 교체
  7. AiLog.applyDescription() 호출 → isApplied=true, appliedAt 기록


## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인
- [x] 예외 케이스 확인 (해당 시)

### 확인 방법 (선택)
1.  ./gradlew test --tests "com.dfdt.delivery.domain.ai.*"
2. 
3. 

## ⚠️ 영향 범위 (해당 시 체크)
- [x] API 스펙 변경 (신규 엔드포인트 추가 (PATCH .../apply))
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [x] 문서(Swagger/README) 수정
- [x] 타 도메인 영향 (Product 엔티티에 applyAiDescription() 메서드 추가, 기존 동작 변경 없음)

## 👀 리뷰 포인트 (선택)
 - storeId 이중 검증 (path variable vs aiLog.storeId): URL 위변조 방지
  목적입니다. aiLogId만으로는 타인 가게의 로그에 접근할 수 있어
  cross-check를 추가했습니다.
  - MASTER 쿼리 최적화: MASTER 역할은
  storeRepository.findByStoreIdAndNotDeleted() 호출 자체를 스킵합니다.
  소유권 검증이 불필요하므로 DB 쿼리 1회 절약입니다.
  - @Transactional 내 이중 엔티티 업데이트: product.applyAiDescription() +
   aiLog.applyDescription() 모두 dirty-checking으로 처리합니다. 별도
  save() 없이 하나의 트랜잭션에서 원자적으로 커밋됩니다.
  - productName 전용 미리보기는 적용 불가 (설계 의도): productId=null
  로그는 특정 상품과 연결되지 않으므로 apply를 막았습니다. 신규 상품 등록
  시 AI 설명을 바로 쓰려면 description 필드에 직접 입력하거나, 추후
  Product 생성 API에 aiLogId 연결 기능으로 확장할 수 있습니다.
