### PR TITLE
feat: AI 로그 목록 조회 (통합 검색)

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/AiLogSummaryResult.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/AiLogSummaryResult.java
@@ -1,0 +1,19 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record AiLogSummaryResult(
+        UUID aiLogId,
+        UUID productId,
+        String requestedBy,
+        AiRequestType requestType,
+        String tone,
+        Boolean isSuccess,
+        Boolean isApplied,
+        OffsetDateTime appliedAt,
+        String responseText,
+        OffsetDateTime createdAt
+) {}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/SearchAiLogsQuery.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/SearchAiLogsQuery.java
@@ -1,0 +1,18 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+
+import java.util.UUID;
+
+public record SearchAiLogsQuery(
+        UUID storeId,
+        String requestedBy,
+        UserRole requestedByRole,
+        UUID productId,       // nullable — productId 필터
+        Boolean isApplied,    // nullable — 적용 여부 필터
+        Boolean isSuccess,    // nullable — 성공 여부 필터
+        int page,
+        int size,
+        String sortBy,
+        boolean isAsc
+) {}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/SearchAiLogsUseCase.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/SearchAiLogsUseCase.java
@@ -1,0 +1,9 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import com.dfdt.delivery.domain.ai.application.dto.SearchAiLogsQuery;
+import org.springframework.data.domain.Page;
+
+public interface SearchAiLogsUseCase {
+    Page<AiLogSummaryResult> execute(SearchAiLogsQuery query);
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/SearchAiLogsUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/SearchAiLogsUseCaseImpl.java
@@ -1,0 +1,50 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import com.dfdt.delivery.domain.ai.application.dto.SearchAiLogsQuery;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogCustomRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SearchAiLogsUseCaseImpl implements SearchAiLogsUseCase {
+
+    private final StoreRepository storeRepository;
+    private final AiLogCustomRepository aiLogCustomRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<AiLogSummaryResult> execute(SearchAiLogsQuery query) {
+
+        // OWNER: 본인 가게인지 소유권 확인 (MASTER는 스킵)
+        if (query.requestedByRole() == UserRole.OWNER) {
+            Store store = storeRepository.findByStoreIdAndNotDeleted(query.storeId())
+                    .orElseThrow(() -> new BusinessException(AiErrorCode.STORE_NOT_FOUND));
+            if (!store.getUser().getUsername().equals(query.requestedBy())) {
+                throw new BusinessException(AiErrorCode.STORE_ACCESS_DENIED);
+            }
+        }
+
+        Sort.Direction direction = query.isAsc() ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Pageable pageable = PageRequest.of(query.page(), query.size(), Sort.by(direction, query.sortBy()));
+
+        return aiLogCustomRepository.searchAiLogs(
+                query.storeId(),
+                query.productId(),
+                query.isApplied(),
+                query.isSuccess(),
+                pageable
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/domain/repository/AiLogCustomRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/domain/repository/AiLogCustomRepository.java
@@ -1,0 +1,18 @@
+package com.dfdt.delivery.domain.ai.domain.repository;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface AiLogCustomRepository {
+
+    Page<AiLogSummaryResult> searchAiLogs(
+            UUID storeId,
+            UUID productId,
+            Boolean isApplied,
+            Boolean isSuccess,
+            Pageable pageable
+    );
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/persistence/AiLogCustomRepositoryImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/persistence/AiLogCustomRepositoryImpl.java
@@ -1,0 +1,113 @@
+package com.dfdt.delivery.domain.ai.infrastructure.persistence;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogCustomRepository;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static com.dfdt.delivery.domain.ai.domain.entity.QAiLogEntity.aiLogEntity;
+
+@Repository
+@RequiredArgsConstructor
+public class AiLogCustomRepositoryImpl implements AiLogCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<AiLogSummaryResult> searchAiLogs(
+            UUID storeId,
+            UUID productId,
+            Boolean isApplied,
+            Boolean isSuccess,
+            Pageable pageable
+    ) {
+        List<AiLogSummaryResult> content = queryFactory
+                .select(Projections.constructor(AiLogSummaryResult.class,
+                        aiLogEntity.aiLogId,
+                        aiLogEntity.productId,
+                        aiLogEntity.requestedBy,
+                        aiLogEntity.requestType,
+                        aiLogEntity.tone,
+                        aiLogEntity.isSuccess,
+                        aiLogEntity.isApplied,
+                        aiLogEntity.appliedAt,
+                        aiLogEntity.responseText,
+                        aiLogEntity.createAudit.createdAt
+                ))
+                .from(aiLogEntity)
+                .where(
+                        aiLogEntity.storeId.eq(storeId),
+                        aiLogEntity.softDeleteAudit.deletedAt.isNull(),
+                        productIdEq(productId),
+                        isAppliedEq(isApplied),
+                        isSuccessEq(isSuccess)
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(buildOrderSpecifiers(pageable))
+                .fetch();
+
+        Long total = queryFactory
+                .select(aiLogEntity.count())
+                .from(aiLogEntity)
+                .where(
+                        aiLogEntity.storeId.eq(storeId),
+                        aiLogEntity.softDeleteAudit.deletedAt.isNull(),
+                        productIdEq(productId),
+                        isAppliedEq(isApplied),
+                        isSuccessEq(isSuccess)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    private BooleanExpression productIdEq(UUID productId) {
+        return productId == null ? null : aiLogEntity.productId.eq(productId);
+    }
+
+    private BooleanExpression isAppliedEq(Boolean isApplied) {
+        return isApplied == null ? null : aiLogEntity.isApplied.eq(isApplied);
+    }
+
+    private BooleanExpression isSuccessEq(Boolean isSuccess) {
+        return isSuccess == null ? null : aiLogEntity.isSuccess.eq(isSuccess);
+    }
+
+    private OrderSpecifier<?>[] buildOrderSpecifiers(Pageable pageable) {
+        List<OrderSpecifier<?>> orders = new ArrayList<>();
+
+        if (pageable.getSort() != null) {
+            for (Sort.Order sortOrder : pageable.getSort()) {
+                Order direction = sortOrder.isAscending() ? Order.ASC : Order.DESC;
+                switch (sortOrder.getProperty()) {
+                    case "appliedAt":
+                        orders.add(new OrderSpecifier<>(direction, aiLogEntity.appliedAt));
+                        break;
+                    default:
+                        orders.add(new OrderSpecifier<>(direction, aiLogEntity.createAudit.createdAt));
+                        break;
+                }
+            }
+        }
+
+        if (orders.isEmpty()) {
+            orders.add(new OrderSpecifier<>(Order.DESC, aiLogEntity.createAudit.createdAt));
+        }
+
+        return orders.toArray(new OrderSpecifier[0]);
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
@@ -1,18 +1,23 @@
 package com.dfdt.delivery.domain.ai.presentation.controller;
 
 import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
 import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionCommand;
 import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionCommand;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionResult;
+import com.dfdt.delivery.domain.ai.application.dto.SearchAiLogsQuery;
 import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.SearchAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.presentation.dto.request.GenerateDescriptionRequest;
+import com.dfdt.delivery.domain.ai.presentation.dto.response.AiLogSummaryResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.ApplyDescriptionResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.GenerateDescriptionResponse;
 import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -28,6 +33,40 @@ public class AiDescriptionController {
 
     private final GenerateDescriptionUseCase generateDescriptionUseCase;
     private final ApplyDescriptionUseCase applyDescriptionUseCase;
+    private final SearchAiLogsUseCase searchAiLogsUseCase;
+
+    /**
+     * AI 로그 목록 조회 (API-AI-101)
+     * GET /api/v1/ai/stores/{storeId}/logs
+     *
+     * - OWNER: 본인 가게 로그만 조회 가능 (UseCase에서 소유권 체크)
+     * - MASTER: 모든 가게 로그 조회 가능
+     */
+    @GetMapping("/stores/{storeId}/logs")
+    @PreAuthorize("hasAnyRole('OWNER', 'MASTER')")
+    public ResponseEntity<ApiResponseDto<Page<AiLogSummaryResponse>>> searchAiLogs(
+            @PathVariable UUID storeId,
+            @RequestParam(required = false) UUID productId,
+            @RequestParam(required = false) Boolean isApplied,
+            @RequestParam(required = false) Boolean isSuccess,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+            @RequestParam(defaultValue = "false") boolean isAsc,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        SearchAiLogsQuery query = new SearchAiLogsQuery(
+                storeId, userDetails.getUsername(), userDetails.getRole(),
+                productId, isApplied, isSuccess, page, size, sortBy, isAsc
+        );
+        Page<AiLogSummaryResult> results = searchAiLogsUseCase.execute(query);
+
+        return ApiResponseDto.success(
+                HttpStatus.OK.value(),
+                "AI 로그 목록을 조회했습니다.",
+                results.map(AiLogSummaryResponse::from)
+        );
+    }
 
     /**
      * AI 상품 설명 미리보기 생성 (API-AI-001)

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/AiLogSummaryResponse.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/AiLogSummaryResponse.java
@@ -1,0 +1,38 @@
+package com.dfdt.delivery.domain.ai.presentation.dto.response;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record AiLogSummaryResponse(
+        UUID aiLogId,
+        UUID productId,
+        String requestedBy,
+        AiRequestType requestType,
+        String tone,
+        Boolean isSuccess,
+        Boolean isApplied,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+        OffsetDateTime appliedAt,
+        String responseText,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+        OffsetDateTime createdAt
+) {
+    public static AiLogSummaryResponse from(AiLogSummaryResult result) {
+        return new AiLogSummaryResponse(
+                result.aiLogId(),
+                result.productId(),
+                result.requestedBy(),
+                result.requestType(),
+                result.tone(),
+                result.isSuccess(),
+                result.isApplied(),
+                result.appliedAt(),
+                result.responseText(),
+                result.createdAt()
+        );
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/SearchAiLogsUseCaseImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/SearchAiLogsUseCaseImplTest.java
@@ -1,0 +1,221 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import com.dfdt.delivery.domain.ai.application.dto.SearchAiLogsQuery;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogCustomRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SearchAiLogsUseCaseImpl 테스트")
+class SearchAiLogsUseCaseImplTest {
+
+    @InjectMocks
+    private SearchAiLogsUseCaseImpl useCase;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private AiLogCustomRepository aiLogCustomRepository;
+
+    private UUID storeId;
+    private UUID productId;
+
+    @BeforeEach
+    void setUp() {
+        storeId = UUID.randomUUID();
+        productId = UUID.randomUUID();
+    }
+
+    // ──────────────────────────────────────────────────
+    // 정상 케이스
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("정상 요청")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("OWNER - 소유권 검증 통과 후 AI 로그 Page 반환")
+        void ownerShouldReturnAiLogs() {
+            // given — 모의 객체를 먼저 변수로 생성 후 stubbing (내부 given 중첩 방지)
+            Store store = mockStore("owner123");
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(store));
+
+            Page<AiLogSummaryResult> mockPage = mockPage(2);
+            given(aiLogCustomRepository.searchAiLogs(any(), any(), any(), any(), any()))
+                    .willReturn(mockPage);
+
+            SearchAiLogsQuery query = ownerQuery("owner123", null, null, null);
+
+            // when
+            Page<AiLogSummaryResult> result = useCase.execute(query);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(2);
+            verify(storeRepository).findByStoreIdAndNotDeleted(storeId);
+            verify(aiLogCustomRepository).searchAiLogs(eq(storeId), isNull(), isNull(), isNull(), any());
+        }
+
+        @Test
+        @DisplayName("MASTER - 소유권 검증 없이 AI 로그 Page 반환")
+        void masterShouldSkipOwnershipCheck() {
+            // given
+            Page<AiLogSummaryResult> mockPage = mockPage(3);
+            given(aiLogCustomRepository.searchAiLogs(any(), any(), any(), any(), any()))
+                    .willReturn(mockPage);
+
+            SearchAiLogsQuery query = new SearchAiLogsQuery(
+                    storeId, "master", UserRole.MASTER, null, null, null, 0, 10, "createdAt", false
+            );
+
+            // when
+            Page<AiLogSummaryResult> result = useCase.execute(query);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(3);
+            verify(storeRepository, never()).findByStoreIdAndNotDeleted(any());
+        }
+
+        @Test
+        @DisplayName("OWNER - isApplied=true 필터 조건이 CustomRepository로 그대로 전달된다")
+        void ownerWithIsAppliedFilterPassedThrough() {
+            // given
+            Store store = mockStore("owner123");
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(store));
+            given(aiLogCustomRepository.searchAiLogs(any(), any(), any(), any(), any()))
+                    .willReturn(mockPage(1));
+
+            SearchAiLogsQuery query = ownerQuery("owner123", null, true, null);
+
+            // when
+            useCase.execute(query);
+
+            // then: isApplied=true가 전달되는지 확인
+            verify(aiLogCustomRepository).searchAiLogs(eq(storeId), isNull(), eq(true), isNull(), any());
+        }
+
+        @Test
+        @DisplayName("OWNER - productId 필터 조건이 CustomRepository로 그대로 전달된다")
+        void ownerWithProductIdFilterPassedThrough() {
+            // given
+            Store store = mockStore("owner123");
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(store));
+            given(aiLogCustomRepository.searchAiLogs(any(), any(), any(), any(), any()))
+                    .willReturn(mockPage(1));
+
+            SearchAiLogsQuery query = ownerQuery("owner123", productId, null, null);
+
+            // when
+            useCase.execute(query);
+
+            // then: productId가 전달되는지 확인
+            verify(aiLogCustomRepository).searchAiLogs(eq(storeId), eq(productId), isNull(), isNull(), any());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 소유권 / 가게 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("소유권 / 가게 예외")
+    class OwnershipFailureTests {
+
+        @Test
+        @DisplayName("OWNER - 가게가 존재하지 않으면 STORE_NOT_FOUND 예외 발생")
+        void shouldThrowWhenStoreNotFound() {
+            // given
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId))
+                    .willReturn(Optional.empty());
+
+            SearchAiLogsQuery query = ownerQuery("owner123", null, null, null);
+
+            // when & then
+            assertThatThrownBy(() -> useCase.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_NOT_FOUND));
+
+            verify(aiLogCustomRepository, never()).searchAiLogs(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("OWNER - 본인 가게가 아니면 STORE_ACCESS_DENIED 예외 발생")
+        void shouldThrowWhenNotOwner() {
+            // given: storeId의 owner는 "realOwner", 요청자는 "intruder"
+            Store store = mockStore("realOwner");
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(store));
+
+            SearchAiLogsQuery query = ownerQuery("intruder", null, null, null);
+
+            // when & then
+            assertThatThrownBy(() -> useCase.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_ACCESS_DENIED));
+
+            verify(aiLogCustomRepository, never()).searchAiLogs(any(), any(), any(), any(), any());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 헬퍼 메서드
+    // ──────────────────────────────────────────────────
+
+    private SearchAiLogsQuery ownerQuery(String username, UUID productId, Boolean isApplied, Boolean isSuccess) {
+        return new SearchAiLogsQuery(
+                storeId, username, UserRole.OWNER,
+                productId, isApplied, isSuccess,
+                0, 10, "createdAt", false
+        );
+    }
+
+    private Store mockStore(String ownerUsername) {
+        User mockUser = mock(User.class);
+        given(mockUser.getUsername()).willReturn(ownerUsername);
+        Store mockStore = mock(Store.class);
+        given(mockStore.getUser()).willReturn(mockUser);
+        return mockStore;
+    }
+
+    private Page<AiLogSummaryResult> mockPage(int count) {
+        List<AiLogSummaryResult> list = new java.util.ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            list.add(new AiLogSummaryResult(
+                    UUID.randomUUID(), productId, "owner123",
+                    AiRequestType.PRODUCT_DESCRIPTION, "FRIENDLY",
+                    true, false, null, "테스트 응답", OffsetDateTime.now()
+            ));
+        }
+        return new PageImpl<>(list, PageRequest.of(0, 10), count);
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
@@ -1,10 +1,13 @@
 package com.dfdt.delivery.domain.ai.presentation.controller;
 
 import com.dfdt.delivery.common.config.SecurityConfig;
+import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
 import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.SearchAiLogsUseCase;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
 import com.dfdt.delivery.domain.ai.domain.entity.enums.Tone;
 import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
 import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetailsService;
@@ -28,9 +31,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -55,6 +63,9 @@ class AiDescriptionControllerTest {
 
     @MockBean
     private ApplyDescriptionUseCase applyDescriptionUseCase;
+
+    @MockBean
+    private SearchAiLogsUseCase searchAiLogsUseCase;
 
     @MockBean
     private com.dfdt.delivery.domain.auth.infrastructure.jwt.JwtProvider jwtProvider;
@@ -324,6 +335,85 @@ class AiDescriptionControllerTest {
 
             mockMvc.perform(patch("/api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/apply",
                             storeId, aiLogId)
+                            .with(user(customerDetails)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // API-AI-101: AI 로그 목록 조회
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AI 로그 목록 조회 (API-AI-101)")
+    class SearchAiLogsTests {
+
+        @Test
+        @DisplayName("OWNER가 요청하면 200과 빈 Page를 반환한다")
+        void ownerShouldReturn200WithPage() throws Exception {
+            // given
+            Page<AiLogSummaryResult> emptyPage =
+                    new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+            given(searchAiLogsUseCase.execute(any())).willReturn(emptyPage);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/descriptions", storeId)
+                            .with(user(ownerDetails)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.totalElements").value(0));
+        }
+
+        @Test
+        @DisplayName("OWNER가 데이터가 있는 경우 200과 Page를 반환한다")
+        void ownerShouldReturn200WithContent() throws Exception {
+            // given
+            UUID aiLogId = UUID.randomUUID();
+            AiLogSummaryResult item = new AiLogSummaryResult(
+                    aiLogId, null, "owner123",
+                    AiRequestType.PRODUCT_DESCRIPTION, "FRIENDLY",
+                    true, false, null, "바삭한 치킨입니다!", OffsetDateTime.now()
+            );
+            Page<AiLogSummaryResult> page =
+                    new PageImpl<>(List.of(item), PageRequest.of(0, 10), 1);
+            given(searchAiLogsUseCase.execute(any())).willReturn(page);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/descriptions", storeId)
+                            .with(user(ownerDetails)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.content[0].aiLogId").value(aiLogId.toString()))
+                    .andExpect(jsonPath("$.data.content[0].responseText").value("바삭한 치킨입니다!"));
+        }
+
+        @Test
+        @DisplayName("MASTER도 200을 반환한다")
+        void masterShouldReturn200() throws Exception {
+            // given
+            given(searchAiLogsUseCase.execute(any()))
+                    .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/descriptions", storeId)
+                            .with(user(masterDetails)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 요청은 4xx를 반환한다")
+        void unauthenticatedShouldReturn4xx() throws Exception {
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/descriptions", storeId))
+                    .andExpect(status().is4xxClientError());
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 역할은 403을 반환한다")
+        void customerShouldReturn403() throws Exception {
+            User customer = User.builder()
+                    .username("customer1").name("고객").password("pw").role(UserRole.CUSTOMER).build();
+            CustomUserDetails customerDetails = new CustomUserDetails(customer);
+
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/descriptions", storeId)
                             .with(user(customerDetails)))
                     .andExpect(status().isForbidden());
         }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

## 📌 작업 내용
 AI 생성 로그 목록을 페이지네이션 + 복합 필터로 조회하는 API를 구현

## ✅ 주요 변경 사항

 ### 신규 파일 (8개)

파일 | 설명
-- | --
SearchAiLogsQuery | UseCase 입력 커맨드 (storeId, 필터 3종, 페이지 파라미터)
AiLogSummaryResult | UseCase 출력 record (목록 단일 항목)
SearchAiLogsUseCase | UseCase 인터페이스
SearchAiLogsUseCaseImpl | 소유권 검증 → Pageable 생성 → CustomRepo 위임
AiLogCustomRepository | QueryDSL 전용 도메인 인터페이스
AiLogCustomRepositoryImpl | QueryDSL 구현체 (동적 필터 + 정렬 + 페이지네이션)
AiLogSummaryResponse | Presentation 응답 DTO

  ### 수정 파일 (1개)

  - `AiDescriptionController` — `GET /stores/{storeId}/logs` 엔드포인트
  추가

  ---


## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인
- [x] 예외 케이스 확인 (해당 시)

Step | 엔드포인트 | 기대 결과
-- | -- | --
4 | GET /logs | 200, totalElements ≥ 2
5 | ?isApplied=true | 200, apply된 로그만
6 | ?isApplied=false | 200, 미적용 로그만
7 | ?isSuccess=true | 200, 성공 로그만
8 | ?productId=$PRODUCT_ID | 200, 해당 상품 로그만
9 | ?page=0&size=1&isAsc=true | 200, totalPages=2
10 | 복합 필터 | 200, 교집합 결과
11 | MASTER 토큰 | 200
12 | 토큰 없음 | 4xx
13 | CUSTOMER | 403
14 | 타 OWNER | 403 AI-4032

### 확인 방법 (선택)
1. 
2. 
3. 

## ⚠️ 영향 범위 (해당 시 체크)
- [x] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [x] 문서(Swagger/README) 수정

## 👀 리뷰 포인트 (선택)
  - `AiLogCustomRepositoryImpl` — `BooleanExpression` 헬퍼 메서드
  3개(`productIdEq`, `isAppliedEq`, `isSuccessEq`)
  - `given()` 중첩 stubbing 이슈 방지 패턴 — 모의 객체를 먼저 변수로 만든
  뒤 `given()` 적용 (Mockito STRICT_STUBS 호환)

