### PR TITLE
feat: AI 로그 상세 조회

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/AiLogDetailResult.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/AiLogDetailResult.java
@@ -1,0 +1,65 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import com.dfdt.delivery.domain.ai.domain.entity.AiLogEntity;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record AiLogDetailResult(
+        UUID aiLogId,
+        UUID storeId,
+        UUID productId,
+        String requestedBy,
+        AiRequestType requestType,
+        String tone,
+        String inputPrompt,
+        String finalPrompt,
+        String responseText,
+        Boolean isSuccess,
+        String errorCode,
+        String errorMessage,
+        String modelName,
+        Integer responseTimeMs,
+        Integer promptCharCount,
+        Integer responseCharCount,
+        Boolean isApplied,
+        OffsetDateTime appliedAt,
+        String appliedBy,
+        UUID sourceAiLogId,
+        String previousDescription,
+        OffsetDateTime rolledBackAt,
+        String rolledBackBy,
+        String keywordsSnapshot,
+        OffsetDateTime createdAt
+) {
+    public static AiLogDetailResult from(AiLogEntity entity) {
+        return new AiLogDetailResult(
+                entity.getAiLogId(),
+                entity.getStoreId(),
+                entity.getProductId(),
+                entity.getRequestedBy(),
+                entity.getRequestType(),
+                entity.getTone(),
+                entity.getInputPrompt(),
+                entity.getFinalPrompt(),
+                entity.getResponseText(),
+                entity.getIsSuccess(),
+                entity.getErrorCode(),
+                entity.getErrorMessage(),
+                entity.getModelName(),
+                entity.getResponseTimeMs(),
+                entity.getPromptCharCount(),
+                entity.getResponseCharCount(),
+                entity.getIsApplied(),
+                entity.getAppliedAt(),
+                entity.getAppliedBy(),
+                entity.getSourceAiLogId(),
+                entity.getPreviousDescription(),
+                entity.getRolledBackAt(),
+                entity.getRolledBackBy(),
+                entity.getKeywordsSnapshot(),
+                entity.getCreateAudit() != null ? entity.getCreateAudit().getCreatedAt() : null
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/GetAiLogDetailQuery.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/GetAiLogDetailQuery.java
@@ -1,0 +1,12 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+
+import java.util.UUID;
+
+public record GetAiLogDetailQuery(
+        UUID storeId,
+        UUID aiLogId,
+        String requestedBy,
+        UserRole requestedByRole
+) {}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiLogDetailUseCase.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiLogDetailUseCase.java
@@ -1,0 +1,8 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiLogDetailResult;
+import com.dfdt.delivery.domain.ai.application.dto.GetAiLogDetailQuery;
+
+public interface GetAiLogDetailUseCase {
+    AiLogDetailResult execute(GetAiLogDetailQuery query);
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiLogDetailUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiLogDetailUseCaseImpl.java
@@ -1,0 +1,47 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.AiLogDetailResult;
+import com.dfdt.delivery.domain.ai.application.dto.GetAiLogDetailQuery;
+import com.dfdt.delivery.domain.ai.domain.entity.AiLogEntity;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GetAiLogDetailUseCaseImpl implements GetAiLogDetailUseCase {
+
+    private final AiLogRepository aiLogRepository;
+    private final StoreRepository storeRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public AiLogDetailResult execute(GetAiLogDetailQuery query) {
+
+        // 1. AI 로그 조회
+        AiLogEntity aiLog = aiLogRepository.findById(query.aiLogId())
+                .orElseThrow(() -> new BusinessException(AiErrorCode.AI_LOG_NOT_FOUND));
+
+        // 2. storeId 일치 검증 (URL 위변조 방지)
+        if (!aiLog.getStoreId().equals(query.storeId())) {
+            throw new BusinessException(AiErrorCode.STORE_NOT_FOUND);
+        }
+
+        // 3. OWNER 권한: 본인 가게인지 소유권 확인 (MASTER는 스킵)
+        if (query.requestedByRole() == UserRole.OWNER) {
+            Store store = storeRepository.findByStoreIdAndNotDeleted(query.storeId())
+                    .orElseThrow(() -> new BusinessException(AiErrorCode.STORE_NOT_FOUND));
+            if (!store.getUser().getUsername().equals(query.requestedBy())) {
+                throw new BusinessException(AiErrorCode.STORE_ACCESS_DENIED);
+            }
+        }
+
+        return AiLogDetailResult.from(aiLog);
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
@@ -1,16 +1,20 @@
 package com.dfdt.delivery.domain.ai.presentation.controller;
 
 import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.ai.application.dto.AiLogDetailResult;
 import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
 import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionCommand;
 import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionCommand;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionResult;
+import com.dfdt.delivery.domain.ai.application.dto.GetAiLogDetailQuery;
 import com.dfdt.delivery.domain.ai.application.dto.SearchAiLogsQuery;
 import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.GetAiLogDetailUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.presentation.dto.request.GenerateDescriptionRequest;
+import com.dfdt.delivery.domain.ai.presentation.dto.response.AiLogDetailResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiLogSummaryResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.ApplyDescriptionResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.GenerateDescriptionResponse;
@@ -34,6 +38,7 @@ public class AiDescriptionController {
     private final GenerateDescriptionUseCase generateDescriptionUseCase;
     private final ApplyDescriptionUseCase applyDescriptionUseCase;
     private final SearchAiLogsUseCase searchAiLogsUseCase;
+    private final GetAiLogDetailUseCase getAiLogDetailUseCase;
 
     /**
      * AI 로그 목록 조회 (API-AI-101)
@@ -65,6 +70,32 @@ public class AiDescriptionController {
                 HttpStatus.OK.value(),
                 "AI 로그 목록을 조회했습니다.",
                 results.map(AiLogSummaryResponse::from)
+        );
+    }
+
+    /**
+     * AI 로그 상세 조회 (API-AI-102)
+     * GET /api/v1/ai/stores/{storeId}/logs/{aiLogId}
+     *
+     * - OWNER: 본인 가게 로그만 조회 가능 (UseCase에서 소유권 체크)
+     * - MASTER: 모든 가게 로그 조회 가능
+     */
+    @GetMapping("/stores/{storeId}/logs/{aiLogId}")
+    @PreAuthorize("hasAnyRole('OWNER', 'MASTER')")
+    public ResponseEntity<ApiResponseDto<AiLogDetailResponse>> getAiLogDetail(
+            @PathVariable UUID storeId,
+            @PathVariable UUID aiLogId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        GetAiLogDetailQuery query = new GetAiLogDetailQuery(
+                storeId, aiLogId, userDetails.getUsername(), userDetails.getRole()
+        );
+        AiLogDetailResult result = getAiLogDetailUseCase.execute(query);
+
+        return ApiResponseDto.success(
+                HttpStatus.OK.value(),
+                "AI 로그 상세 정보를 조회했습니다.",
+                AiLogDetailResponse.from(result)
         );
     }
 

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/AiLogDetailResponse.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/AiLogDetailResponse.java
@@ -1,0 +1,69 @@
+package com.dfdt.delivery.domain.ai.presentation.dto.response;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiLogDetailResult;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record AiLogDetailResponse(
+        UUID aiLogId,
+        UUID storeId,
+        UUID productId,
+        String requestedBy,
+        AiRequestType requestType,
+        String tone,
+        String inputPrompt,
+        String finalPrompt,
+        String responseText,
+        Boolean isSuccess,
+        String errorCode,
+        String errorMessage,
+        String modelName,
+        Integer responseTimeMs,
+        Integer promptCharCount,
+        Integer responseCharCount,
+        Boolean isApplied,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+        OffsetDateTime appliedAt,
+        String appliedBy,
+        UUID sourceAiLogId,
+        String previousDescription,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+        OffsetDateTime rolledBackAt,
+        String rolledBackBy,
+        String keywordsSnapshot,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX")
+        OffsetDateTime createdAt
+) {
+    public static AiLogDetailResponse from(AiLogDetailResult result) {
+        return new AiLogDetailResponse(
+                result.aiLogId(),
+                result.storeId(),
+                result.productId(),
+                result.requestedBy(),
+                result.requestType(),
+                result.tone(),
+                result.inputPrompt(),
+                result.finalPrompt(),
+                result.responseText(),
+                result.isSuccess(),
+                result.errorCode(),
+                result.errorMessage(),
+                result.modelName(),
+                result.responseTimeMs(),
+                result.promptCharCount(),
+                result.responseCharCount(),
+                result.isApplied(),
+                result.appliedAt(),
+                result.appliedBy(),
+                result.sourceAiLogId(),
+                result.previousDescription(),
+                result.rolledBackAt(),
+                result.rolledBackBy(),
+                result.keywordsSnapshot(),
+                result.createdAt()
+        );
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiLogDetailUseCaseImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiLogDetailUseCaseImplTest.java
@@ -1,0 +1,223 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.AiLogDetailResult;
+import com.dfdt.delivery.domain.ai.application.dto.GetAiLogDetailQuery;
+import com.dfdt.delivery.domain.ai.domain.entity.AiLogEntity;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetAiLogDetailUseCaseImpl 테스트")
+class GetAiLogDetailUseCaseImplTest {
+
+    @InjectMocks
+    private GetAiLogDetailUseCaseImpl useCase;
+
+    @Mock
+    private AiLogRepository aiLogRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    private UUID storeId;
+    private UUID aiLogId;
+    private UUID productId;
+
+    @BeforeEach
+    void setUp() {
+        storeId = UUID.randomUUID();
+        aiLogId = UUID.randomUUID();
+        productId = UUID.randomUUID();
+    }
+
+    // ──────────────────────────────────────────────────
+    // 정상 케이스
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("정상 요청")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("OWNER - 소유권 검증 통과 후 AI 로그 상세 반환")
+        void ownerShouldReturnAiLogDetail() {
+            // given
+            AiLogEntity aiLog = mockAiLog(storeId, productId);
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(aiLog));
+
+            Store store = mockStore("owner123");
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(store));
+
+            GetAiLogDetailQuery query = ownerQuery("owner123");
+
+            // when
+            AiLogDetailResult result = useCase.execute(query);
+
+            // then
+            assertThat(result.aiLogId()).isEqualTo(aiLogId);
+            assertThat(result.storeId()).isEqualTo(storeId);
+            verify(storeRepository).findByStoreIdAndNotDeleted(storeId);
+        }
+
+        @Test
+        @DisplayName("MASTER - 소유권 검증 없이 AI 로그 상세 반환")
+        void masterShouldSkipOwnershipCheck() {
+            // given
+            AiLogEntity aiLog = mockAiLog(storeId, productId);
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(aiLog));
+
+            GetAiLogDetailQuery query = new GetAiLogDetailQuery(storeId, aiLogId, "master", UserRole.MASTER);
+
+            // when
+            AiLogDetailResult result = useCase.execute(query);
+
+            // then
+            assertThat(result.aiLogId()).isEqualTo(aiLogId);
+            verify(storeRepository, never()).findByStoreIdAndNotDeleted(any());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // AI 로그 / storeId 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AI 로그 / storeId 예외")
+    class NotFoundTests {
+
+        @Test
+        @DisplayName("aiLogId에 해당하는 로그가 없으면 AI_LOG_NOT_FOUND 예외 발생")
+        void shouldThrowWhenAiLogNotFound() {
+            // given
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.empty());
+
+            GetAiLogDetailQuery query = ownerQuery("owner123");
+
+            // when & then
+            assertThatThrownBy(() -> useCase.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.AI_LOG_NOT_FOUND));
+
+            verify(storeRepository, never()).findByStoreIdAndNotDeleted(any());
+        }
+
+        @Test
+        @DisplayName("storeId가 AI 로그의 storeId와 다르면 STORE_NOT_FOUND 예외 발생")
+        void shouldThrowWhenStoreIdMismatch() {
+            // given: AI 로그의 storeId는 다른 UUID
+            UUID differentStoreId = UUID.randomUUID();
+            AiLogEntity aiLog = mockAiLog(differentStoreId, productId);
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(aiLog));
+
+            GetAiLogDetailQuery query = ownerQuery("owner123"); // query.storeId() == storeId
+
+            // when & then
+            assertThatThrownBy(() -> useCase.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_NOT_FOUND));
+
+            verify(storeRepository, never()).findByStoreIdAndNotDeleted(any());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 소유권 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("소유권 예외")
+    class OwnershipFailureTests {
+
+        @Test
+        @DisplayName("OWNER - 가게가 존재하지 않으면 STORE_NOT_FOUND 예외 발생")
+        void shouldThrowWhenStoreNotFound() {
+            // given
+            AiLogEntity aiLog = mockAiLog(storeId, productId);
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(aiLog));
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.empty());
+
+            GetAiLogDetailQuery query = ownerQuery("owner123");
+
+            // when & then
+            assertThatThrownBy(() -> useCase.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("OWNER - 본인 가게가 아니면 STORE_ACCESS_DENIED 예외 발생")
+        void shouldThrowWhenNotOwner() {
+            // given: AI 로그의 가게 owner는 "realOwner", 요청자는 "intruder"
+            AiLogEntity aiLog = mockAiLog(storeId, productId);
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(aiLog));
+
+            Store store = mockStore("realOwner");
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(store));
+
+            GetAiLogDetailQuery query = ownerQuery("intruder");
+
+            // when & then
+            assertThatThrownBy(() -> useCase.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_ACCESS_DENIED));
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 헬퍼 메서드
+    // ──────────────────────────────────────────────────
+
+    private GetAiLogDetailQuery ownerQuery(String username) {
+        return new GetAiLogDetailQuery(storeId, aiLogId, username, UserRole.OWNER);
+    }
+
+    private Store mockStore(String ownerUsername) {
+        User mockUser = mock(User.class);
+        given(mockUser.getUsername()).willReturn(ownerUsername);
+        Store mockStore = mock(Store.class);
+        given(mockStore.getUser()).willReturn(mockUser);
+        return mockStore;
+    }
+
+    private AiLogEntity mockAiLog(UUID aiLogStoreId, UUID aiLogProductId) {
+        AiLogEntity aiLog = mock(AiLogEntity.class);
+        // storeId 일치 검증에 항상 사용
+        given(aiLog.getStoreId()).willReturn(aiLogStoreId);
+        // 성공 경로에서 AiLogDetailResult.from() 매핑 시 사용 (예외 경로에서는 lenient)
+        lenient().doReturn(aiLogId).when(aiLog).getAiLogId();
+        lenient().doReturn(aiLogProductId).when(aiLog).getProductId();
+        lenient().doReturn("owner123").when(aiLog).getRequestedBy();
+        lenient().doReturn(AiRequestType.PRODUCT_DESCRIPTION).when(aiLog).getRequestType();
+        lenient().doReturn("FRIENDLY").when(aiLog).getTone();
+        lenient().doReturn("테스트 프롬프트").when(aiLog).getInputPrompt();
+        lenient().doReturn("최종 프롬프트").when(aiLog).getFinalPrompt();
+        lenient().doReturn("테스트 응답").when(aiLog).getResponseText();
+        lenient().doReturn(true).when(aiLog).getIsSuccess();
+        lenient().doReturn(false).when(aiLog).getIsApplied();
+        lenient().doReturn(null).when(aiLog).getCreateAudit();
+        return aiLog;
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
@@ -1,11 +1,13 @@
 package com.dfdt.delivery.domain.ai.presentation.controller;
 
 import com.dfdt.delivery.common.config.SecurityConfig;
+import com.dfdt.delivery.domain.ai.application.dto.AiLogDetailResult;
 import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
 import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.GetAiLogDetailUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
 import com.dfdt.delivery.domain.ai.domain.entity.enums.Tone;
@@ -66,6 +68,9 @@ class AiDescriptionControllerTest {
 
     @MockBean
     private SearchAiLogsUseCase searchAiLogsUseCase;
+
+    @MockBean
+    private GetAiLogDetailUseCase getAiLogDetailUseCase;
 
     @MockBean
     private com.dfdt.delivery.domain.auth.infrastructure.jwt.JwtProvider jwtProvider;
@@ -341,6 +346,87 @@ class AiDescriptionControllerTest {
     }
 
     // ──────────────────────────────────────────────────
+    // API-AI-102: AI 로그 상세 조회
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AI 로그 상세 조회 (API-AI-102)")
+    class GetAiLogDetailTests {
+
+        private UUID aiLogId;
+        private UUID productId;
+
+        @BeforeEach
+        void setUpDetail() {
+            aiLogId = UUID.randomUUID();
+            productId = UUID.randomUUID();
+        }
+
+        @Test
+        @DisplayName("OWNER가 요청하면 200과 상세 정보를 반환한다")
+        void ownerShouldReturn200WithDetail() throws Exception {
+            // given
+            AiLogDetailResult mockResult = new AiLogDetailResult(
+                    aiLogId, storeId, productId, "owner123",
+                    AiRequestType.PRODUCT_DESCRIPTION, "FRIENDLY",
+                    "테스트 프롬프트", "최종 프롬프트", "바삭한 치킨입니다!",
+                    true, null, null, "gemini-pro", 1200,
+                    10, 10, false, null, null, null, null, null, null, null,
+                    OffsetDateTime.now()
+            );
+            given(getAiLogDetailUseCase.execute(any())).willReturn(mockResult);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/logs/{aiLogId}", storeId, aiLogId)
+                            .with(user(ownerDetails)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.aiLogId").value(aiLogId.toString()))
+                    .andExpect(jsonPath("$.data.storeId").value(storeId.toString()))
+                    .andExpect(jsonPath("$.data.responseText").value("바삭한 치킨입니다!"))
+                    .andExpect(jsonPath("$.data.inputPrompt").value("테스트 프롬프트"))
+                    .andExpect(jsonPath("$.data.isSuccess").value(true));
+        }
+
+        @Test
+        @DisplayName("MASTER도 200을 반환한다")
+        void masterShouldReturn200() throws Exception {
+            // given
+            AiLogDetailResult mockResult = new AiLogDetailResult(
+                    aiLogId, storeId, productId, "owner123",
+                    AiRequestType.PRODUCT_DESCRIPTION, "SALESY",
+                    "프롬프트", "최종", "설명입니다.", true, null, null,
+                    "gemini-pro", 800, 6, 4, false, null, null, null, null,
+                    null, null, null, OffsetDateTime.now()
+            );
+            given(getAiLogDetailUseCase.execute(any())).willReturn(mockResult);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/logs/{aiLogId}", storeId, aiLogId)
+                            .with(user(masterDetails)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 요청은 4xx를 반환한다")
+        void unauthenticatedShouldReturn4xx() throws Exception {
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/logs/{aiLogId}", storeId, aiLogId))
+                    .andExpect(status().is4xxClientError());
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 역할은 403을 반환한다")
+        void customerShouldReturn403() throws Exception {
+            User customer = User.builder()
+                    .username("customer1").name("고객").password("pw").role(UserRole.CUSTOMER).build();
+            CustomUserDetails customerDetails = new CustomUserDetails(customer);
+
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/logs/{aiLogId}", storeId, aiLogId)
+                            .with(user(customerDetails)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
     // API-AI-101: AI 로그 목록 조회
     // ──────────────────────────────────────────────────
     @Nested
@@ -356,7 +442,7 @@ class AiDescriptionControllerTest {
             given(searchAiLogsUseCase.execute(any())).willReturn(emptyPage);
 
             // when & then
-            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/descriptions", storeId)
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/logs", storeId)
                             .with(user(ownerDetails)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status").value(200))
@@ -378,7 +464,7 @@ class AiDescriptionControllerTest {
             given(searchAiLogsUseCase.execute(any())).willReturn(page);
 
             // when & then
-            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/descriptions", storeId)
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/logs", storeId)
                             .with(user(ownerDetails)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.totalElements").value(1))
@@ -394,7 +480,7 @@ class AiDescriptionControllerTest {
                     .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
 
             // when & then
-            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/descriptions", storeId)
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/logs", storeId)
                             .with(user(masterDetails)))
                     .andExpect(status().isOk());
         }
@@ -402,7 +488,7 @@ class AiDescriptionControllerTest {
         @Test
         @DisplayName("인증되지 않은 요청은 4xx를 반환한다")
         void unauthenticatedShouldReturn4xx() throws Exception {
-            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/descriptions", storeId))
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/logs", storeId))
                     .andExpect(status().is4xxClientError());
         }
 
@@ -413,7 +499,7 @@ class AiDescriptionControllerTest {
                     .username("customer1").name("고객").password("pw").role(UserRole.CUSTOMER).build();
             CustomUserDetails customerDetails = new CustomUserDetails(customer);
 
-            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/descriptions", storeId)
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/logs", storeId)
                             .with(user(customerDetails)))
                     .andExpect(status().isForbidden());
         }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

## 📌 작업 내용
AI 로그 상세 조회 구현   

## ✅ 주요 변경 사항

 신규 파일 (5개)

Layer | 파일 | 설명
-- | -- | --
Application | GetAiLogDetailQuery | UseCase 입력 record
Application | AiLogDetailResult | UseCase 출력 record
Application | GetAiLogDetailUseCase | UseCase 인터페이스
Application | GetAiLogDetailUseCaseImpl | UseCase 구현
Presentation | AiLogDetailResponse | API 응답 DTO

  수정 파일 (2개)
  - AiDescriptionController — 신규 엔드포인트 + GetAiLogDetailUseCase
  의존성 추가
  - AiDescriptionControllerTest — API-AI-102 테스트 추가 및 API-AI-101 URL
   오타 수정 (/descriptions → /logs)

  UseCase 처리 흐름 (3단계 검증)

  1. aiLogId 조회 → 없으면 AI_LOG_NOT_FOUND (404)
  2. aiLog.storeId == query.storeId 검증 → 불일치 시 STORE_NOT_FOUND (404)
    ← URL 위변조 방지
  3. OWNER인 경우: 가게 소유권 확인 → STORE_NOT_FOUND /
  STORE_ACCESS_DENIED
     MASTER인 경우: 소유권 검증 스킵


## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인
- [x] 예외 케이스 확인 (해당 시)

### 확인 방법 (선택)

 GetAiLogDetailUseCaseImplTest — 6개 테스트 신규 추가

분류 | 시나리오 | 기대 결과
-- | -- | --
정상 | OWNER 접근 | 상세 로그 반환
정상 | MASTER 접근 | 상세 로그 반환 (소유권 검증 생략)
예외 | aiLogId 없음 | AI_LOG_NOT_FOUND
예외 | storeId 불일치 | STORE_NOT_FOUND
예외 | 가게 삭제/미존재 | STORE_NOT_FOUND
예외 | 타인 가게 접근 | STORE_ACCESS_DENIED

 AiDescriptionControllerTest — 4개 테스트 추가

테스트 시나리오 | 기대 결과
-- | --
OWNER 요청 | 200 + 전체 필드 응답 검증
MASTER 요청 | 200
미인증 요청 | 4xx
CUSTOMER 요청 | 403

  BUILD SUCCESSFUL — AI 도메인 전체 테스트 통과


## ⚠️ 영향 범위 (해당 시 체크)
- [x] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [x] 문서(Swagger/README) 수정

## 👀 리뷰 포인트 (선택)
  1. 3단계 검증 순서의 의도
  storeId 일치 검증(2단계)을 OWNER 소유권 조회(3단계) 앞에 배치했습니다.
  DB 조회 없이 메모리에서 URL 위변조를 차단하여, 삭제된 가게의 로그에
  OWNER가 접근하는 논리 오류를 사전에 방지합니다.
  ApplyDescriptionUseCaseImpl과 동일한 패턴입니다.
  2. 목록 vs. 상세 응답 분리 설계
  AiLogSummaryResult(목록)와 AiLogDetailResult(상세)를 별도 record로
  분리했습니다. 상세에서는 inputPrompt, finalPrompt, errorMessage 등
  디버깅용 내부 필드를 추가로 노출합니다.
  3. STRICT_STUBS 대응 — lenient() 적용
  mockAiLog() 헬퍼에서 예외 경로 테스트 시 호출되지 않는
  stub(getRequestedBy, getRequestType 등)에 lenient().doReturn()을
  적용하여 Mockito UnnecessaryStubbingException을 회피했습니다.

