### PR TITLE
feat: 상품 기준 AI 로그 목록 조회

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/SearchProductAiLogsQuery.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/SearchProductAiLogsQuery.java
@@ -1,0 +1,18 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+
+import java.util.UUID;
+
+public record SearchProductAiLogsQuery(
+        UUID storeId,
+        UUID productId,
+        String requestedBy,
+        UserRole requestedByRole,
+        Boolean isApplied,
+        Boolean isSuccess,
+        int page,
+        int size,
+        String sortBy,
+        boolean isAsc
+) {}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/SearchProductAiLogsUseCase.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/SearchProductAiLogsUseCase.java
@@ -1,0 +1,9 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import com.dfdt.delivery.domain.ai.application.dto.SearchProductAiLogsQuery;
+import org.springframework.data.domain.Page;
+
+public interface SearchProductAiLogsUseCase {
+    Page<AiLogSummaryResult> execute(SearchProductAiLogsQuery query);
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/SearchProductAiLogsUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/SearchProductAiLogsUseCaseImpl.java
@@ -1,0 +1,56 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import com.dfdt.delivery.domain.ai.application.dto.SearchProductAiLogsQuery;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogCustomRepository;
+import com.dfdt.delivery.domain.product.domain.repository.ProductRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SearchProductAiLogsUseCaseImpl implements SearchProductAiLogsUseCase {
+
+    private final StoreRepository storeRepository;
+    private final ProductRepository productRepository;
+    private final AiLogCustomRepository aiLogCustomRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<AiLogSummaryResult> execute(SearchProductAiLogsQuery query) {
+
+        // 1. OWNER: 본인 가게인지 소유권 확인 (MASTER는 스킵)
+        if (query.requestedByRole() == UserRole.OWNER) {
+            Store store = storeRepository.findByStoreIdAndNotDeleted(query.storeId())
+                    .orElseThrow(() -> new BusinessException(AiErrorCode.STORE_NOT_FOUND));
+            if (!store.getUser().getUsername().equals(query.requestedBy())) {
+                throw new BusinessException(AiErrorCode.STORE_ACCESS_DENIED);
+            }
+        }
+
+        // 2. 상품이 해당 가게에 속하는지 검증
+        productRepository.findByProductIdAndStoreId(query.productId(), query.storeId())
+                .orElseThrow(() -> new BusinessException(AiErrorCode.PRODUCT_NOT_FOUND));
+
+        Sort.Direction direction = query.isAsc() ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Pageable pageable = PageRequest.of(query.page(), query.size(), Sort.by(direction, query.sortBy()));
+
+        return aiLogCustomRepository.searchAiLogs(
+                query.storeId(),
+                query.productId(),
+                query.isApplied(),
+                query.isSuccess(),
+                pageable
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
@@ -9,10 +9,12 @@ import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionCommand;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.GetAiLogDetailQuery;
 import com.dfdt.delivery.domain.ai.application.dto.SearchAiLogsQuery;
+import com.dfdt.delivery.domain.ai.application.dto.SearchProductAiLogsQuery;
 import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetAiLogDetailUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchAiLogsUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.SearchProductAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.presentation.dto.request.GenerateDescriptionRequest;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiLogDetailResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiLogSummaryResponse;
@@ -39,6 +41,7 @@ public class AiDescriptionController {
     private final ApplyDescriptionUseCase applyDescriptionUseCase;
     private final SearchAiLogsUseCase searchAiLogsUseCase;
     private final GetAiLogDetailUseCase getAiLogDetailUseCase;
+    private final SearchProductAiLogsUseCase searchProductAiLogsUseCase;
 
     /**
      * AI 로그 목록 조회 (API-AI-101)
@@ -96,6 +99,39 @@ public class AiDescriptionController {
                 HttpStatus.OK.value(),
                 "AI 로그 상세 정보를 조회했습니다.",
                 AiLogDetailResponse.from(result)
+        );
+    }
+
+    /**
+     * 상품 기준 AI 로그 목록 조회 (API-AI-103)
+     * GET /api/v1/ai/stores/{storeId}/products/{productId}/logs
+     *
+     * - OWNER: 본인 가게 상품 로그만 조회 가능 (UseCase에서 소유권 체크)
+     * - MASTER: 모든 가게 상품 로그 조회 가능
+     */
+    @GetMapping("/stores/{storeId}/products/{productId}/logs")
+    @PreAuthorize("hasAnyRole('OWNER', 'MASTER')")
+    public ResponseEntity<ApiResponseDto<Page<AiLogSummaryResponse>>> searchProductAiLogs(
+            @PathVariable UUID storeId,
+            @PathVariable UUID productId,
+            @RequestParam(required = false) Boolean isApplied,
+            @RequestParam(required = false) Boolean isSuccess,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "createdAt") String sortBy,
+            @RequestParam(defaultValue = "false") boolean isAsc,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        SearchProductAiLogsQuery query = new SearchProductAiLogsQuery(
+                storeId, productId, userDetails.getUsername(), userDetails.getRole(),
+                isApplied, isSuccess, page, size, sortBy, isAsc
+        );
+        Page<AiLogSummaryResult> results = searchProductAiLogsUseCase.execute(query);
+
+        return ApiResponseDto.success(
+                HttpStatus.OK.value(),
+                "상품 AI 로그 목록을 조회했습니다.",
+                results.map(AiLogSummaryResponse::from)
         );
     }
 

--- a/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/SearchProductAiLogsUseCaseImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/SearchProductAiLogsUseCaseImplTest.java
@@ -1,0 +1,259 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import com.dfdt.delivery.domain.ai.application.dto.SearchProductAiLogsQuery;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogCustomRepository;
+import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.product.domain.repository.ProductRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SearchProductAiLogsUseCaseImpl 테스트")
+class SearchProductAiLogsUseCaseImplTest {
+
+    @InjectMocks
+    private SearchProductAiLogsUseCaseImpl useCase;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private AiLogCustomRepository aiLogCustomRepository;
+
+    private UUID storeId;
+    private UUID productId;
+
+    @BeforeEach
+    void setUp() {
+        storeId = UUID.randomUUID();
+        productId = UUID.randomUUID();
+    }
+
+    // ──────────────────────────────────────────────────
+    // 정상 케이스
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("정상 요청")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("OWNER - 소유권 검증 통과 후 상품 AI 로그 Page 반환")
+        void ownerShouldReturnProductAiLogs() {
+            // given
+            Store store = mockStore("owner123");
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(store));
+            given(productRepository.findByProductIdAndStoreId(productId, storeId))
+                    .willReturn(Optional.of(mock(Product.class)));
+            Page<AiLogSummaryResult> mockPage = mockPage(2);
+            given(aiLogCustomRepository.searchAiLogs(any(), any(), any(), any(), any()))
+                    .willReturn(mockPage);
+
+            SearchProductAiLogsQuery query = ownerQuery("owner123", null, null);
+
+            // when
+            Page<AiLogSummaryResult> result = useCase.execute(query);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(2);
+            verify(storeRepository).findByStoreIdAndNotDeleted(storeId);
+            verify(productRepository).findByProductIdAndStoreId(productId, storeId);
+            verify(aiLogCustomRepository).searchAiLogs(eq(storeId), eq(productId), isNull(), isNull(), any());
+        }
+
+        @Test
+        @DisplayName("MASTER - 소유권 검증 없이 상품 AI 로그 Page 반환")
+        void masterShouldSkipOwnershipCheck() {
+            // given
+            given(productRepository.findByProductIdAndStoreId(productId, storeId))
+                    .willReturn(Optional.of(mock(Product.class)));
+            given(aiLogCustomRepository.searchAiLogs(any(), any(), any(), any(), any()))
+                    .willReturn(mockPage(3));
+
+            SearchProductAiLogsQuery query = new SearchProductAiLogsQuery(
+                    storeId, productId, "master", UserRole.MASTER,
+                    null, null, 0, 10, "createdAt", false
+            );
+
+            // when
+            Page<AiLogSummaryResult> result = useCase.execute(query);
+
+            // then
+            assertThat(result.getTotalElements()).isEqualTo(3);
+            verify(storeRepository, never()).findByStoreIdAndNotDeleted(any());
+        }
+
+        @Test
+        @DisplayName("OWNER - isApplied=true 필터가 CustomRepository로 전달된다")
+        void ownerWithIsAppliedFilterPassedThrough() {
+            // given
+            Store store = mockStore("owner123");
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(store));
+            given(productRepository.findByProductIdAndStoreId(productId, storeId))
+                    .willReturn(Optional.of(mock(Product.class)));
+            given(aiLogCustomRepository.searchAiLogs(any(), any(), any(), any(), any()))
+                    .willReturn(mockPage(1));
+
+            SearchProductAiLogsQuery query = ownerQuery("owner123", true, null);
+
+            // when
+            useCase.execute(query);
+
+            // then
+            verify(aiLogCustomRepository).searchAiLogs(eq(storeId), eq(productId), eq(true), isNull(), any());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 소유권 / 가게 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("소유권 / 가게 예외")
+    class OwnershipFailureTests {
+
+        @Test
+        @DisplayName("OWNER - 가게가 존재하지 않으면 STORE_NOT_FOUND 예외 발생")
+        void shouldThrowWhenStoreNotFound() {
+            // given
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.empty());
+
+            SearchProductAiLogsQuery query = ownerQuery("owner123", null, null);
+
+            // when & then
+            assertThatThrownBy(() -> useCase.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_NOT_FOUND));
+
+            verify(productRepository, never()).findByProductIdAndStoreId(any(), any());
+            verify(aiLogCustomRepository, never()).searchAiLogs(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("OWNER - 본인 가게가 아니면 STORE_ACCESS_DENIED 예외 발생")
+        void shouldThrowWhenNotOwner() {
+            // given
+            Store store = mockStore("realOwner");
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(store));
+
+            SearchProductAiLogsQuery query = ownerQuery("intruder", null, null);
+
+            // when & then
+            assertThatThrownBy(() -> useCase.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_ACCESS_DENIED));
+
+            verify(productRepository, never()).findByProductIdAndStoreId(any(), any());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 상품 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("상품 예외")
+    class ProductFailureTests {
+
+        @Test
+        @DisplayName("OWNER - 상품이 해당 가게에 존재하지 않으면 PRODUCT_NOT_FOUND 예외 발생")
+        void shouldThrowWhenProductNotFound() {
+            // given
+            Store store = mockStore("owner123");
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(store));
+            given(productRepository.findByProductIdAndStoreId(productId, storeId))
+                    .willReturn(Optional.empty());
+
+            SearchProductAiLogsQuery query = ownerQuery("owner123", null, null);
+
+            // when & then
+            assertThatThrownBy(() -> useCase.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.PRODUCT_NOT_FOUND));
+
+            verify(aiLogCustomRepository, never()).searchAiLogs(any(), any(), any(), any(), any());
+        }
+
+        @Test
+        @DisplayName("MASTER - 상품이 해당 가게에 존재하지 않으면 PRODUCT_NOT_FOUND 예외 발생")
+        void masterShouldThrowWhenProductNotFound() {
+            // given
+            given(productRepository.findByProductIdAndStoreId(productId, storeId))
+                    .willReturn(Optional.empty());
+
+            SearchProductAiLogsQuery query = new SearchProductAiLogsQuery(
+                    storeId, productId, "master", UserRole.MASTER,
+                    null, null, 0, 10, "createdAt", false
+            );
+
+            // when & then
+            assertThatThrownBy(() -> useCase.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.PRODUCT_NOT_FOUND));
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 헬퍼 메서드
+    // ──────────────────────────────────────────────────
+
+    private SearchProductAiLogsQuery ownerQuery(String username, Boolean isApplied, Boolean isSuccess) {
+        return new SearchProductAiLogsQuery(
+                storeId, productId, username, UserRole.OWNER,
+                isApplied, isSuccess, 0, 10, "createdAt", false
+        );
+    }
+
+    private Store mockStore(String ownerUsername) {
+        User mockUser = mock(User.class);
+        given(mockUser.getUsername()).willReturn(ownerUsername);
+        Store mockStore = mock(Store.class);
+        given(mockStore.getUser()).willReturn(mockUser);
+        return mockStore;
+    }
+
+    private Page<AiLogSummaryResult> mockPage(int count) {
+        List<AiLogSummaryResult> list = new java.util.ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            list.add(new AiLogSummaryResult(
+                    UUID.randomUUID(), productId, "owner123",
+                    AiRequestType.PRODUCT_DESCRIPTION, "FRIENDLY",
+                    true, false, null, "테스트 응답", OffsetDateTime.now()
+            ));
+        }
+        return new PageImpl<>(list, PageRequest.of(0, 10), count);
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
@@ -9,6 +9,7 @@ import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetAiLogDetailUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchAiLogsUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.SearchProductAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
 import com.dfdt.delivery.domain.ai.domain.entity.enums.Tone;
 import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
@@ -71,6 +72,9 @@ class AiDescriptionControllerTest {
 
     @MockBean
     private GetAiLogDetailUseCase getAiLogDetailUseCase;
+
+    @MockBean
+    private SearchProductAiLogsUseCase searchProductAiLogsUseCase;
 
     @MockBean
     private com.dfdt.delivery.domain.auth.infrastructure.jwt.JwtProvider jwtProvider;
@@ -500,6 +504,98 @@ class AiDescriptionControllerTest {
             CustomUserDetails customerDetails = new CustomUserDetails(customer);
 
             mockMvc.perform(get("/api/v1/ai/stores/{storeId}/logs", storeId)
+                            .with(user(customerDetails)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // API-AI-103: 상품 기준 AI 로그 목록 조회
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("상품 기준 AI 로그 목록 조회 (API-AI-103)")
+    class SearchProductAiLogsTests {
+
+        private UUID productId;
+
+        @BeforeEach
+        void setUpProduct() {
+            productId = UUID.randomUUID();
+        }
+
+        @Test
+        @DisplayName("OWNER가 요청하면 200과 빈 Page를 반환한다")
+        void ownerShouldReturn200WithEmptyPage() throws Exception {
+            // given
+            Page<AiLogSummaryResult> emptyPage =
+                    new PageImpl<>(List.of(), PageRequest.of(0, 10), 0);
+            given(searchProductAiLogsUseCase.execute(any())).willReturn(emptyPage);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/products/{productId}/logs",
+                            storeId, productId)
+                            .with(user(ownerDetails)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.totalElements").value(0));
+        }
+
+        @Test
+        @DisplayName("OWNER가 데이터가 있는 경우 200과 Page를 반환한다")
+        void ownerShouldReturn200WithContent() throws Exception {
+            // given
+            UUID aiLogId = UUID.randomUUID();
+            AiLogSummaryResult item = new AiLogSummaryResult(
+                    aiLogId, productId, "owner123",
+                    AiRequestType.PRODUCT_DESCRIPTION, "FRIENDLY",
+                    true, false, null, "바삭한 치킨입니다!", OffsetDateTime.now()
+            );
+            Page<AiLogSummaryResult> page =
+                    new PageImpl<>(List.of(item), PageRequest.of(0, 10), 1);
+            given(searchProductAiLogsUseCase.execute(any())).willReturn(page);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/products/{productId}/logs",
+                            storeId, productId)
+                            .with(user(ownerDetails)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.totalElements").value(1))
+                    .andExpect(jsonPath("$.data.content[0].aiLogId").value(aiLogId.toString()))
+                    .andExpect(jsonPath("$.data.content[0].productId").value(productId.toString()))
+                    .andExpect(jsonPath("$.data.content[0].responseText").value("바삭한 치킨입니다!"));
+        }
+
+        @Test
+        @DisplayName("MASTER도 200을 반환한다")
+        void masterShouldReturn200() throws Exception {
+            // given
+            given(searchProductAiLogsUseCase.execute(any()))
+                    .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/products/{productId}/logs",
+                            storeId, productId)
+                            .with(user(masterDetails)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 요청은 4xx를 반환한다")
+        void unauthenticatedShouldReturn4xx() throws Exception {
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/products/{productId}/logs",
+                            storeId, productId))
+                    .andExpect(status().is4xxClientError());
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 역할은 403을 반환한다")
+        void customerShouldReturn403() throws Exception {
+            User customer = User.builder()
+                    .username("customer1").name("고객").password("pw").role(UserRole.CUSTOMER).build();
+            CustomUserDetails customerDetails = new CustomUserDetails(customer);
+
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/products/{productId}/logs",
+                            storeId, productId)
                             .with(user(customerDetails)))
                     .andExpect(status().isForbidden());
         }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

## 📌 작업 내용
API-AI-103 상품 기준 AI 로그 목록 조회 구현 

## ✅ 주요 변경 사항

작업 내용
                                                                          
  엔드포인트: GET /api/v1/ai/stores/{storeId}/products/{productId}/logs   
  권한: OWNER, MASTER

  신규 파일 (3개)

파일 | 설명
-- | --
SearchProductAiLogsQuery | productId 필수(Path Variable) Query record
SearchProductAiLogsUseCase | 인터페이스
SearchProductAiLogsUseCaseImpl | 구현체

  수정 파일 (1개)
  - AiDescriptionController — SearchProductAiLogsUseCase 의존성 + 신규
  엔드포인트 추가

  UseCase 처리 흐름 (3단계)

  1. OWNER인 경우: 가게 소유권 확인 → STORE_NOT_FOUND /
  STORE_ACCESS_DENIED
     MASTER인 경우: 소유권 검증 스킵
  2. 상품이 해당 가게에 속하는지 검증 (productId + storeId) →
  PRODUCT_NOT_FOUND (404)
  3. AiLogCustomRepository.searchAiLogs(storeId, productId, isApplied,
  isSuccess, pageable) 호출

  API-AI-101(가게 기준) 대비 차이점
구분 | AI-101 | AI-103
-- | -- | --
productId | Optional 쿼리 파라미터 | Required Path Variable
상품 존재 검증 | 없음 | productRepository.findByProductIdAndStoreId()
응답 구조 | Page<AiLogSummaryResponse> | 동일 재사용



## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인
- [x] 예외 케이스 확인 (해당 시)

### 확인 방법 (선택)
  ---
  단위 테스트 결과

  SearchProductAiLogsUseCaseImplTest — 6개 테스트 신규 추가

분류 | 테스트
-- | --
정상 | OWNER — 소유권 검증 통과 후 상품 AI 로그 Page 반환
정상 | MASTER — 소유권 검증 없이 상품 AI 로그 Page 반환 (storeRepository 미호출 검증)
정상 | OWNER — isApplied=true 필터가 CustomRepository로 그대로 전달됨
소유권 예외 | 가게 삭제/미존재 → STORE_NOT_FOUND (상품 조회 미실행 검증)
소유권 예외 | 타인 가게 접근 → STORE_ACCESS_DENIED (상품 조회 미실행 검증)
상품 예외 | OWNER — 상품이 가게에 미존재 → PRODUCT_NOT_FOUND
상품 예외 | MASTER — 상품이 가게에 미존재 → PRODUCT_NOT_FOUND

AiDescriptionControllerTest — 5개 테스트 추가

테스트


--
OWNER 요청 → 200 + 빈 Page
OWNER 요청 → 200 + 데이터 포함 Page (aiLogId, productId, responseText 검증)
MASTER 요청 → 200
미인증 요청 → 4xx
CUSTOMER 요청 → 403

 BUILD SUCCESSFUL — AI 도메인 전체 테스트 통과


## ⚠️ 영향 범위 (해당 시 체크)
- [ ] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정

## 👀 리뷰 포인트 (선택)
  1. OWNER 소유권 검증을 상품 검증보다 먼저 수행하는 이유
  권한 없는 사용자가 타 가게의 productId를 무작위로 탐색(ID enumeration)하는 것을 DB 조회 없이 먼저 차단합니다. 순서가 바뀌면   productRepository 쿼리가 먼저 실행되어 불필요한 DB 부하와 정보 노출 가능성이 생깁니다.
  2. AiLogCustomRepository.searchAiLogs() 재사용 productId를 필수 Path Variable로 받아 기존 AI-101의 CustomRepository
  메서드에 그대로 전달합니다. 새로운 쿼리 메서드 없이 기존 동적 필터를 활용하므로 QueryDSL 코드 중복이 없습니다.
  3. 응답 DTO 재사용
  AI-101과 동일한 Page<AiLogSummaryResponse> 구조를 반환합니다. 상품 기준이어도 목록 단위 항목 구조가 동일하므로 별도 DTO를 추가하지 않았습니다.

