### PR TITLE
feat: AI 프롬프트 규칙 미리보기 API 구현

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/AiPromptRulesResult.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/AiPromptRulesResult.java
@@ -1,0 +1,16 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import java.util.List;
+
+public record AiPromptRulesResult(
+        String mandatorySuffix,
+        int maxResponseLength,
+        int maxInputPromptLength,
+        int maxProductNameLength,
+        int maxKeywordsCount,
+        int maxKeywordItemLength,
+        List<ToneRuleResult> availableTones,
+        String promptTemplate
+) {
+    public record ToneRuleResult(String tone, String instruction) {}
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetPromptRulesUseCase.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetPromptRulesUseCase.java
@@ -1,0 +1,7 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiPromptRulesResult;
+
+public interface GetPromptRulesUseCase {
+    AiPromptRulesResult execute();
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetPromptRulesUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetPromptRulesUseCaseImpl.java
@@ -1,0 +1,46 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiPromptRulesResult;
+import com.dfdt.delivery.domain.ai.domain.policy.AiPromptPolicy;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class GetPromptRulesUseCaseImpl implements GetPromptRulesUseCase {
+
+    private final AiPromptPolicy aiPromptPolicy;
+
+    // GenerateDescriptionRequest @Size 제약 조건과 동일한 값을 여기서 상수로 통합 관리
+    private static final int MAX_INPUT_PROMPT_LENGTH = 300;
+    private static final int MAX_PRODUCT_NAME_LENGTH = 120;
+    private static final int MAX_KEYWORDS_COUNT = 10;
+    private static final int MAX_KEYWORD_ITEM_LENGTH = 30;
+
+    private static final String PROMPT_TEMPLATE =
+            "[톤 지시문]\n" +
+            "(상품명: {productName})\n" +
+            "(키워드: {keyword1, keyword2, ...})\n" +
+            "{inputPrompt}" + AiPromptPolicy.MANDATORY_SUFFIX;
+
+    @Override
+    public AiPromptRulesResult execute() {
+        List<AiPromptRulesResult.ToneRuleResult> tones = aiPromptPolicy.availableToneRules()
+                .stream()
+                .map(r -> new AiPromptRulesResult.ToneRuleResult(r.tone(), r.instruction()))
+                .toList();
+
+        return new AiPromptRulesResult(
+                AiPromptPolicy.MANDATORY_SUFFIX,
+                AiPromptPolicy.MAX_RESPONSE_LENGTH,
+                MAX_INPUT_PROMPT_LENGTH,
+                MAX_PRODUCT_NAME_LENGTH,
+                MAX_KEYWORDS_COUNT,
+                MAX_KEYWORD_ITEM_LENGTH,
+                tones,
+                PROMPT_TEMPLATE
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/domain/policy/AiPromptPolicy.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/domain/policy/AiPromptPolicy.java
@@ -3,6 +3,7 @@ package com.dfdt.delivery.domain.ai.domain.policy;
 import com.dfdt.delivery.domain.ai.domain.entity.enums.Tone;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Component
@@ -10,6 +11,20 @@ public class AiPromptPolicy {
 
     public static final String MANDATORY_SUFFIX = " 답변을 최대한 간결하게 50자 이하로 작성해줘.";
     public static final int MAX_RESPONSE_LENGTH = 50;
+
+    /**
+     * 톤(Tone)과 해당 지시문을 쌍으로 나타내는 도메인 레코드
+     */
+    public record ToneRule(String tone, String instruction) {}
+
+    /**
+     * 사용 가능한 모든 톤 규칙 목록을 반환합니다.
+     */
+    public List<ToneRule> availableToneRules() {
+        return Arrays.stream(Tone.values())
+                .map(t -> new ToneRule(t.name(), toneInstruction(t)))
+                .toList();
+    }
 
     /**
      * 최종 프롬프트를 조립합니다.

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
@@ -15,12 +15,14 @@ import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.CheckAiHealthUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetAiLogDetailUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.GetPromptRulesUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchProductAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.presentation.dto.request.GenerateDescriptionRequest;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiHealthResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiLogDetailResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiLogSummaryResponse;
+import com.dfdt.delivery.domain.ai.presentation.dto.response.AiPromptRulesResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.ApplyDescriptionResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.GenerateDescriptionResponse;
 import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
@@ -46,6 +48,7 @@ public class AiDescriptionController {
     private final GetAiLogDetailUseCase getAiLogDetailUseCase;
     private final SearchProductAiLogsUseCase searchProductAiLogsUseCase;
     private final CheckAiHealthUseCase checkAiHealthUseCase;
+    private final GetPromptRulesUseCase getPromptRulesUseCase;
 
     /**
      * AI 연동 상태 확인 (API-AI-201)
@@ -62,6 +65,23 @@ public class AiDescriptionController {
                 HttpStatus.OK.value(),
                 "AI 연동 상태를 조회했습니다.",
                 AiHealthResponse.from(result)
+        );
+    }
+
+    /**
+     * AI 프롬프트 규칙 미리보기 (API-AI-202)
+     * GET /api/v1/ai/prompt-rules
+     *
+     * - OWNER / MASTER: 프롬프트 구성 규칙(제약 조건, 톤 목록, 강제 문구, 템플릿) 조회
+     * - 외부 API 호출 없음, 항상 HTTP 200 반환
+     */
+    @GetMapping("/prompt-rules")
+    @PreAuthorize("hasAnyRole('OWNER', 'MASTER')")
+    public ResponseEntity<ApiResponseDto<AiPromptRulesResponse>> getPromptRules() {
+        return ApiResponseDto.success(
+                HttpStatus.OK.value(),
+                "AI 프롬프트 규칙을 조회했습니다.",
+                AiPromptRulesResponse.from(getPromptRulesUseCase.execute())
         );
     }
 

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/AiPromptRulesResponse.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/AiPromptRulesResponse.java
@@ -1,0 +1,36 @@
+package com.dfdt.delivery.domain.ai.presentation.dto.response;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiPromptRulesResult;
+
+import java.util.List;
+
+public record AiPromptRulesResponse(
+        String mandatorySuffix,
+        int maxResponseLength,
+        int maxInputPromptLength,
+        int maxProductNameLength,
+        int maxKeywordsCount,
+        int maxKeywordItemLength,
+        List<ToneRuleResponse> availableTones,
+        String promptTemplate
+) {
+    public record ToneRuleResponse(String tone, String instruction) {}
+
+    public static AiPromptRulesResponse from(AiPromptRulesResult result) {
+        List<ToneRuleResponse> tones = result.availableTones()
+                .stream()
+                .map(r -> new ToneRuleResponse(r.tone(), r.instruction()))
+                .toList();
+
+        return new AiPromptRulesResponse(
+                result.mandatorySuffix(),
+                result.maxResponseLength(),
+                result.maxInputPromptLength(),
+                result.maxProductNameLength(),
+                result.maxKeywordsCount(),
+                result.maxKeywordItemLength(),
+                tones,
+                result.promptTemplate()
+        );
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/GetPromptRulesUseCaseImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/GetPromptRulesUseCaseImplTest.java
@@ -1,0 +1,91 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiPromptRulesResult;
+import com.dfdt.delivery.domain.ai.domain.policy.AiPromptPolicy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("GetPromptRulesUseCaseImpl 테스트")
+class GetPromptRulesUseCaseImplTest {
+
+    // AiPromptPolicy는 상태가 없는 순수 도메인 컴포넌트 → 실제 인스턴스 사용
+    private GetPromptRulesUseCaseImpl useCase;
+
+    @BeforeEach
+    void setUp() {
+        useCase = new GetPromptRulesUseCaseImpl(new AiPromptPolicy());
+    }
+
+    // ──────────────────────────────────────────────────
+    // 정적 규칙 반환 검증
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("프롬프트 규칙 조회")
+    class RulesTests {
+
+        @Test
+        @DisplayName("강제 문구와 최대 응답 길이를 올바르게 반환한다")
+        void shouldReturnMandatorySuffixAndMaxLength() {
+            // when
+            AiPromptRulesResult result = useCase.execute();
+
+            // then
+            assertThat(result.mandatorySuffix()).isEqualTo(AiPromptPolicy.MANDATORY_SUFFIX);
+            assertThat(result.maxResponseLength()).isEqualTo(AiPromptPolicy.MAX_RESPONSE_LENGTH);
+        }
+
+        @Test
+        @DisplayName("입력 제약 조건을 올바르게 반환한다")
+        void shouldReturnInputConstraints() {
+            // when
+            AiPromptRulesResult result = useCase.execute();
+
+            // then
+            assertThat(result.maxInputPromptLength()).isEqualTo(300);
+            assertThat(result.maxProductNameLength()).isEqualTo(120);
+            assertThat(result.maxKeywordsCount()).isEqualTo(10);
+            assertThat(result.maxKeywordItemLength()).isEqualTo(30);
+        }
+
+        @Test
+        @DisplayName("3개의 톤 규칙(FRIENDLY, SALESY, INFORMATIVE)을 반환한다")
+        void shouldReturnThreeToneRules() {
+            // when
+            AiPromptRulesResult result = useCase.execute();
+
+            // then
+            assertThat(result.availableTones()).hasSize(3);
+            assertThat(result.availableTones())
+                    .extracting(AiPromptRulesResult.ToneRuleResult::tone)
+                    .containsExactlyInAnyOrder("FRIENDLY", "SALESY", "INFORMATIVE");
+        }
+
+        @Test
+        @DisplayName("각 톤에 대한 지시문이 비어있지 않다")
+        void shouldReturnNonBlankInstructionForEachTone() {
+            // when
+            AiPromptRulesResult result = useCase.execute();
+
+            // then
+            result.availableTones().forEach(tone ->
+                    assertThat(tone.instruction())
+                            .as("톤 '%s'의 지시문이 비어있으면 안 됩니다.", tone.tone())
+                            .isNotBlank()
+            );
+        }
+
+        @Test
+        @DisplayName("프롬프트 템플릿이 강제 문구를 포함한다")
+        void shouldReturnTemplateContainingMandatorySuffix() {
+            // when
+            AiPromptRulesResult result = useCase.execute();
+
+            // then
+            assertThat(result.promptTemplate()).contains(AiPromptPolicy.MANDATORY_SUFFIX);
+        }
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
@@ -6,10 +6,12 @@ import com.dfdt.delivery.domain.ai.application.dto.AiLogDetailResult;
 import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
 import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionResult;
+import com.dfdt.delivery.domain.ai.application.dto.AiPromptRulesResult;
 import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.CheckAiHealthUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetAiLogDetailUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.GetPromptRulesUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchProductAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
@@ -80,6 +82,9 @@ class AiDescriptionControllerTest {
 
     @MockBean
     private CheckAiHealthUseCase checkAiHealthUseCase;
+
+    @MockBean
+    private GetPromptRulesUseCase getPromptRulesUseCase;
 
     @MockBean
     private com.dfdt.delivery.domain.auth.infrastructure.jwt.JwtProvider jwtProvider;
@@ -171,6 +176,77 @@ class AiDescriptionControllerTest {
         @DisplayName("인증되지 않은 요청은 4xx를 반환한다")
         void unauthenticatedShouldReturn4xx() throws Exception {
             mockMvc.perform(get("/api/v1/ai/health"))
+                    .andExpect(status().is4xxClientError());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // API-AI-202: AI 프롬프트 규칙 미리보기
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AI 프롬프트 규칙 미리보기 (API-AI-202)")
+    class GetPromptRulesTests {
+
+        @Test
+        @DisplayName("OWNER가 요청하면 200과 프롬프트 규칙을 반환한다")
+        void ownerShouldReturn200WithPromptRules() throws Exception {
+            // given
+            List<AiPromptRulesResult.ToneRuleResult> tones = List.of(
+                    new AiPromptRulesResult.ToneRuleResult("FRIENDLY", "친근하고 따뜻한 톤으로 작성해줘."),
+                    new AiPromptRulesResult.ToneRuleResult("SALESY", "세일즈 톤으로 구매 욕구를 자극하게 작성해줘."),
+                    new AiPromptRulesResult.ToneRuleResult("INFORMATIVE", "정보 전달 위주의 간결한 톤으로 작성해줘.")
+            );
+            AiPromptRulesResult mockResult = new AiPromptRulesResult(
+                    " 답변을 최대한 간결하게 50자 이하로 작성해줘.", 50,
+                    300, 120, 10, 30,
+                    tones, "[톤 지시문]\n{inputPrompt} 답변을 최대한 간결하게 50자 이하로 작성해줘."
+            );
+            given(getPromptRulesUseCase.execute()).willReturn(mockResult);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/prompt-rules")
+                            .with(user(ownerDetails)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.maxResponseLength").value(50))
+                    .andExpect(jsonPath("$.data.maxInputPromptLength").value(300))
+                    .andExpect(jsonPath("$.data.maxKeywordsCount").value(10))
+                    .andExpect(jsonPath("$.data.availableTones").isArray())
+                    .andExpect(jsonPath("$.data.availableTones.length()").value(3))
+                    .andExpect(jsonPath("$.data.availableTones[0].tone").value("FRIENDLY"));
+        }
+
+        @Test
+        @DisplayName("MASTER도 200을 반환한다")
+        void masterShouldReturn200() throws Exception {
+            // given
+            given(getPromptRulesUseCase.execute()).willReturn(
+                    new AiPromptRulesResult(" 답변을 최대한 간결하게 50자 이하로 작성해줘.", 50,
+                            300, 120, 10, 30, List.of(), "template")
+            );
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/prompt-rules")
+                            .with(user(masterDetails)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 역할은 403을 반환한다")
+        void customerShouldReturn403() throws Exception {
+            User customer = User.builder()
+                    .username("customer1").name("고객").password("pw").role(UserRole.CUSTOMER).build();
+            CustomUserDetails customerDetails = new CustomUserDetails(customer);
+
+            mockMvc.perform(get("/api/v1/ai/prompt-rules")
+                            .with(user(customerDetails)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 요청은 4xx를 반환한다")
+        void unauthenticatedShouldReturn4xx() throws Exception {
+            mockMvc.perform(get("/api/v1/ai/prompt-rules"))
                     .andExpect(status().is4xxClientError());
         }
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

## 📌 작업 내용

GET /api/v1/ai/prompt-rules API 신규 추가

OWNER / MASTER 권한에서 AI 상품 설명 생성 규칙 조회 기능 제공

프롬프트 정책(AiPromptPolicy)을 기반으로 입력 제약 / 톤 규칙 / 템플릿 정보 반환

규칙 정보를 UseCase 레이어를 통해 조회하도록 구조 분리

## ✅ 주요 변경 사항

Layer | 파일 | 역할
-- | -- | --
Domain | AiPromptPolicy | ToneRule 정의 및 availableToneRules() 제공
Application | AiPromptRulesResult | Prompt 규칙 조회 결과 DTO
Application | GetPromptRulesUseCase | UseCase 인터페이스
Application | GetPromptRulesUseCaseImpl | Prompt 정책 기반 결과 생성
Presentation | AiPromptRulesResponse | API 응답 DTO
Presentation | AiDescriptionController | /ai/prompt-rules 엔드포인트 추가


## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인
- [x] 예외 케이스 확인 (해당 시)

### 확인 방법 (선택)
1. 
2. 
3. 

## ⚠️ 영향 범위 (해당 시 체크)
- [x] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정

## 👀 리뷰 포인트 (선택)
리뷰 포인트

1️⃣ Prompt 규칙 조회 API를 UseCase로 분리한 구조가 적절한지

단순 상수 반환 API이지만

향후 확장성을 고려한 설계

2️⃣ AiPromptPolicy 캡슐화 방식

availableToneRules() 공개

toneInstruction() 내부 유지

도메인 정책 노출 범위가 적절한지 확인 부탁드립니다.

3️⃣ 테스트 전략

Policy는 mock 없이 실제 인스턴스 사용

외부 의존성 없는 순수 컴포넌트 테스트 방식

테스트 설계 방향에 대한 의견 부탁드립니다.