### PR TITLE
feat:이미지 생성 AI (PoC)

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/GenerateImageCommand.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/GenerateImageCommand.java
@@ -1,0 +1,24 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AspectRatio;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+
+import java.util.UUID;
+
+/**
+ * 음식 이미지 AI 생성 UseCase 입력 커맨드.
+ * Controller → UseCase 방향으로 전달됩니다.
+ */
+public record GenerateImageCommand(
+        UUID storeId,
+        String requestedBy,        // 인증된 사용자 username
+        UserRole requestedByRole,  // 소유권 체크에 사용 (OWNER만 storeId 검증)
+        UUID productId,            // nullable — productName과 둘 중 하나 필수
+        String productName,        // nullable — productId 없을 때 사용
+        String prompt,             // 이미지 생성 프롬프트 (max 500)
+        AspectRatio aspectRatio,   // nullable — 기본값 SQUARE (UseCase에서 처리)
+        String style,              // nullable — 이미지 스타일 자유 텍스트 (max 50)
+        boolean includeText,       // 이미지에 텍스트 오버레이 포함 여부
+        String text                // includeText=true일 때 필수 (max 50)
+) {
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/GenerateImageResult.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/GenerateImageResult.java
@@ -1,0 +1,14 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import java.util.UUID;
+
+/**
+ * 음식 이미지 AI 생성 UseCase 출력 결과.
+ * UseCase → Controller 방향으로 반환됩니다.
+ */
+public record GenerateImageResult(
+        UUID aiLogId,
+        String imageData,  // base64 인코딩된 이미지 데이터
+        String mimeType    // e.g., "image/png"
+) {
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateImageUseCase.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateImageUseCase.java
@@ -1,0 +1,8 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.domain.ai.application.dto.GenerateImageCommand;
+import com.dfdt.delivery.domain.ai.application.dto.GenerateImageResult;
+
+public interface GenerateImageUseCase {
+    GenerateImageResult execute(GenerateImageCommand command);
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateImageUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateImageUseCaseImpl.java
@@ -1,0 +1,140 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.GenerateImageCommand;
+import com.dfdt.delivery.domain.ai.application.dto.GenerateImageResult;
+import com.dfdt.delivery.domain.ai.domain.client.GeneratedImageData;
+import com.dfdt.delivery.domain.ai.domain.client.ImageGenerationClient;
+import com.dfdt.delivery.domain.ai.domain.entity.AiLogEntity;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AspectRatio;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogRepository;
+import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.product.domain.repository.ProductRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GenerateImageUseCaseImpl implements GenerateImageUseCase {
+
+    private final StoreRepository storeRepository;
+    private final ProductRepository productRepository;
+    private final AiLogRepository aiLogRepository;
+    private final ImageGenerationClient imageGenerationClient;
+
+    @Override
+    @Transactional
+    public GenerateImageResult execute(GenerateImageCommand command) {
+
+        // 1. Store 조회
+        Store store = storeRepository.findByStoreIdAndNotDeleted(command.storeId())
+                .orElseThrow(() -> new BusinessException(AiErrorCode.STORE_NOT_FOUND));
+
+        // 2. OWNER 권한: 본인 가게인지 소유권 확인
+        if (command.requestedByRole() == UserRole.OWNER) {
+            if (!store.getUser().getUsername().equals(command.requestedBy())) {
+                throw new BusinessException(AiErrorCode.STORE_ACCESS_DENIED);
+            }
+        }
+
+        // 3. productId / productName 둘 다 없으면 오류
+        if (command.productId() == null && (command.productName() == null || command.productName().isBlank())) {
+            throw new BusinessException(AiErrorCode.PRODUCT_IDENTIFIER_REQUIRED);
+        }
+
+        // 4. productId가 있으면 Product 조회 및 상품명 확인
+        String resolvedProductName = command.productName();
+        if (command.productId() != null) {
+            Product product = productRepository.findByProductIdAndStoreId(command.productId(), command.storeId())
+                    .orElseThrow(() -> new BusinessException(AiErrorCode.PRODUCT_NOT_FOUND));
+            // getSoftDeleteAudit()이 null이면 활성 상품 (JPA @Embedded 특성상 모든 컬럼 null → 객체 null)
+            if (product.getSoftDeleteAudit() != null && product.getSoftDeleteAudit().isDeleted()) {
+                throw new BusinessException(AiErrorCode.PRODUCT_NOT_FOUND);
+            }
+            resolvedProductName = product.getName();
+        }
+
+        // 5. includeText = true인데 text가 없으면 오류
+        if (command.includeText() && (command.text() == null || command.text().isBlank())) {
+            throw new BusinessException(AiErrorCode.INCLUDE_TEXT_REQUIRED);
+        }
+
+        // 6. aspectRatio 기본값 처리 (null → SQUARE)
+        AspectRatio aspectRatio = command.aspectRatio() != null ? command.aspectRatio() : AspectRatio.SQUARE;
+
+        // 7. 이미지 생성 프롬프트 조립 (aspectRatio는 API 파라미터로 전달하므로 프롬프트에서 제외)
+        String finalPrompt = buildImagePrompt(resolvedProductName, command.prompt(),
+                command.style(), command.includeText(), command.text());
+
+        // 8. 이미지 생성 API 호출 — 실패 시 실패 로그 저장 후 예외 rethrow
+        GeneratedImageData imageData;
+        try {
+            imageData = imageGenerationClient.generate(finalPrompt, aspectRatio.getRatio());
+        } catch (BusinessException e) {
+            aiLogRepository.save(AiLogEntity.failureFoodImageGeneration(
+                    command.storeId(),
+                    command.productId(),
+                    command.requestedBy(),
+                    command.prompt(),
+                    finalPrompt,
+                    e.getErrorCode().getErrorCode(),
+                    e.getMessage(),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            ));
+            throw e;
+        }
+
+        // 9. 성공 로그 저장 (imageData.base64Data를 responseText에 저장)
+        AiLogEntity savedLog = aiLogRepository.save(AiLogEntity.successFoodImageGeneration(
+                command.storeId(),
+                command.productId(),
+                command.requestedBy(),
+                command.prompt(),
+                finalPrompt,
+                imageData.base64Data(),
+                null,
+                null,
+                null,
+                null,
+                null
+        ));
+
+        return new GenerateImageResult(savedLog.getAiLogId(), imageData.base64Data(), imageData.mimeType());
+    }
+
+    /**
+     * 이미지 생성 프롬프트를 조립합니다.
+     * 구성: [음식 사진 생성] + 상품명 + 사용자 프롬프트 + (선택) 스타일 + (선택) 텍스트 오버레이 지시
+     * aspectRatio는 Imagen API의 네이티브 파라미터로 직접 전달되므로 프롬프트에서 제외합니다.
+     */
+    private String buildImagePrompt(String productName, String userPrompt,
+                                    String style, boolean includeText, String text) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("음식 사진을 생성해줘.");
+
+        if (productName != null && !productName.isBlank()) {
+            sb.append(" 상품명: ").append(productName).append(".");
+        }
+
+        sb.append(" ").append(userPrompt).append(".");
+
+        if (style != null && !style.isBlank()) {
+            sb.append(" 스타일: ").append(style).append(".");
+        }
+
+        if (includeText && text != null && !text.isBlank()) {
+            sb.append(" 이미지에 '").append(text).append("' 텍스트를 눈에 잘 띄게 포함해줘.");
+        }
+
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/domain/client/GeneratedImageData.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/domain/client/GeneratedImageData.java
@@ -1,0 +1,11 @@
+package com.dfdt.delivery.domain.ai.domain.client;
+
+/**
+ * 이미지 생성 API의 응답 데이터를 담는 값 객체.
+ * base64 인코딩된 이미지 데이터와 MIME 타입을 포함합니다.
+ */
+public record GeneratedImageData(
+        String base64Data,  // base64 인코딩된 이미지 바이너리
+        String mimeType     // e.g., "image/png"
+) {
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/domain/client/ImageGenerationClient.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/domain/client/ImageGenerationClient.java
@@ -1,0 +1,18 @@
+package com.dfdt.delivery.domain.ai.domain.client;
+
+/**
+ * 외부 이미지 생성 AI API 호출 인터페이스.
+ * 구현체는 infrastructure 계층에 위치합니다.
+ */
+public interface ImageGenerationClient {
+
+    /**
+     * 프롬프트와 비율 옵션을 이미지 생성 API에 전달하여 base64 이미지 데이터를 반환합니다.
+     *
+     * @param prompt      최종 조립된 이미지 생성 프롬프트
+     * @param aspectRatio 이미지 비율 문자열 (예: "1:1", "16:9") — API 네이티브 파라미터로 전달
+     * @return base64 인코딩된 이미지 데이터 및 MIME 타입
+     * @throws com.dfdt.delivery.common.exception.BusinessException AI 호출 실패 시
+     */
+    GeneratedImageData generate(String prompt, String aspectRatio);
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/domain/entity/enums/AspectRatio.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/domain/entity/enums/AspectRatio.java
@@ -1,0 +1,16 @@
+package com.dfdt.delivery.domain.ai.domain.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AspectRatio {
+    SQUARE("1:1", "정사각형"),
+    LANDSCAPE("16:9", "가로형"),
+    PORTRAIT("9:16", "세로형"),
+    STANDARD("4:3", "일반");
+
+    private final String ratio;        // 프롬프트에 삽입될 비율 문자열
+    private final String description;  // 한국어 설명
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiImageWebClient.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiImageWebClient.java
@@ -1,0 +1,110 @@
+package com.dfdt.delivery.domain.ai.infrastructure.client;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.domain.client.GeneratedImageData;
+import com.dfdt.delivery.domain.ai.domain.client.ImageGenerationClient;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.infrastructure.config.GeminiProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Imagen 4 Fast API를 사용한 이미지 생성 클라이언트.
+ *
+ * Google AI Imagen API의 :predict 엔드포인트를 사용합니다.
+ * 요청: instances[0].prompt + parameters.aspectRatio
+ * 응답: predictions[0].bytesBase64Encoded + predictions[0].mimeType
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GeminiImageWebClient implements ImageGenerationClient {
+
+    private final RestClient restClient;
+    private final GeminiProperties properties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public GeneratedImageData generate(String prompt, String aspectRatio) {
+        String url = "/v1beta/models/" + properties.imageModel() + ":predict?key=" + properties.apiKey();
+
+        // Imagen API 요청 형식: instances + parameters
+        Map<String, Object> requestBody = Map.of(
+                "instances", List.of(
+                        Map.of("prompt", prompt)
+                ),
+                "parameters", Map.of(
+                        "sampleCount", 1,
+                        "aspectRatio", aspectRatio
+                )
+        );
+
+        String responseJson;
+        try {
+            responseJson = executeHttpCall(url, requestBody);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[GeminiImageWebClient] Imagen API 호출 실패: {}", e.getMessage(), e);
+            throw new BusinessException(AiErrorCode.EXTERNAL_AI_CALL_FAILED);
+        }
+
+        return parseImage(responseJson);
+    }
+
+    /**
+     * 실제 HTTP 요청을 수행합니다.
+     * 테스트에서 오버라이드하여 HTTP 호출 없이 단위 테스트가 가능합니다.
+     */
+    protected String executeHttpCall(String url, Object body) {
+        return restClient.post()
+                .uri(url)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(body)
+                .retrieve()
+                .body(String.class);
+    }
+
+    /**
+     * Imagen API 응답 JSON에서 base64 이미지 데이터를 추출합니다.
+     * 응답 구조: predictions[0].bytesBase64Encoded + predictions[0].mimeType
+     */
+    GeneratedImageData parseImage(String responseJson) {
+        if (responseJson == null || responseJson.isBlank()) {
+            throw new BusinessException(AiErrorCode.EXTERNAL_AI_EMPTY_RESPONSE);
+        }
+
+        try {
+            JsonNode root = objectMapper.readTree(responseJson);
+            JsonNode predictions = root.path("predictions");
+
+            if (predictions.isMissingNode() || predictions.isEmpty()) {
+                throw new BusinessException(AiErrorCode.EXTERNAL_AI_EMPTY_RESPONSE);
+            }
+
+            JsonNode prediction = predictions.get(0);
+            String base64Data = prediction.path("bytesBase64Encoded").asText(null);
+            String mimeType = prediction.path("mimeType").asText(null);
+
+            if (base64Data == null || base64Data.isBlank()) {
+                throw new BusinessException(AiErrorCode.EXTERNAL_AI_EMPTY_RESPONSE);
+            }
+
+            return new GeneratedImageData(base64Data, mimeType != null ? mimeType : "image/jpeg");
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("[GeminiImageWebClient] Imagen 응답 파싱 실패: {}", e.getMessage(), e);
+            throw new BusinessException(AiErrorCode.EXTERNAL_AI_CALL_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/config/GeminiProperties.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/config/GeminiProperties.java
@@ -9,12 +9,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  *   gemini:
  *     api-key: ...
  *     model: gemini-2.0-flash
+ *     image-model: gemini-2.0-flash-exp
  *     base-url: https://generativelanguage.googleapis.com
  */
 @ConfigurationProperties(prefix = "ai.gemini")
 public record GeminiProperties(
         String apiKey,
         String model,
-        String baseUrl
+        String baseUrl,
+        String imageModel  // 이미지 생성 전용 모델 (responseModalities: IMAGE 지원 모델)
 ) {
 }

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
@@ -18,10 +18,14 @@ import com.dfdt.delivery.domain.ai.application.usecase.CheckAiHealthUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetAiLogDetailUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetPromptRulesUseCase;
+import com.dfdt.delivery.domain.ai.application.dto.GenerateImageCommand;
+import com.dfdt.delivery.domain.ai.application.dto.GenerateImageResult;
+import com.dfdt.delivery.domain.ai.application.usecase.GenerateImageUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.RetryDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchProductAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.presentation.dto.request.GenerateDescriptionRequest;
+import com.dfdt.delivery.domain.ai.presentation.dto.request.GenerateImageRequest;
 import com.dfdt.delivery.domain.ai.presentation.dto.request.RetryDescriptionRequest;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiHealthResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiLogDetailResponse;
@@ -29,6 +33,7 @@ import com.dfdt.delivery.domain.ai.presentation.dto.response.AiLogSummaryRespons
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiPromptRulesResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.ApplyDescriptionResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.GenerateDescriptionResponse;
+import com.dfdt.delivery.domain.ai.presentation.dto.response.GenerateImageResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.RetryDescriptionResponse;
 import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -50,6 +55,7 @@ public class AiDescriptionController {
     private final GenerateDescriptionUseCase generateDescriptionUseCase;
     private final ApplyDescriptionUseCase applyDescriptionUseCase;
     private final RetryDescriptionUseCase retryDescriptionUseCase;
+    private final GenerateImageUseCase generateImageUseCase;
     private final SearchAiLogsUseCase searchAiLogsUseCase;
     private final GetAiLogDetailUseCase getAiLogDetailUseCase;
     private final SearchProductAiLogsUseCase searchProductAiLogsUseCase;
@@ -235,6 +241,31 @@ public class AiDescriptionController {
                 HttpStatus.CREATED.value(),
                 "AI 상품 설명이 재생성되었습니다.",
                 RetryDescriptionResponse.from(result)
+        );
+    }
+
+    /**
+     * AI 음식 이미지 생성 (API-AI-301)
+     * POST /api/v1/ai/stores/{storeId}/images/preview
+     *
+     * - OWNER: 본인 가게만 요청 가능 (UseCase에서 소유권 체크)
+     * - MASTER: 모든 가게 요청 가능
+     * - 응답의 imageData는 base64 인코딩된 이미지 데이터
+     */
+    @PostMapping("/stores/{storeId}/images/preview")
+    @PreAuthorize("hasAnyRole('OWNER', 'MASTER')")
+    public ResponseEntity<ApiResponseDto<GenerateImageResponse>> generateImagePreview(
+            @PathVariable UUID storeId,
+            @Valid @RequestBody GenerateImageRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        GenerateImageCommand command = request.toCommand(storeId, userDetails);
+        GenerateImageResult result = generateImageUseCase.execute(command);
+
+        return ApiResponseDto.success(
+                HttpStatus.CREATED.value(),
+                "AI 음식 이미지가 생성되었습니다.",
+                GenerateImageResponse.from(result)
         );
     }
 

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/request/GenerateImageRequest.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/request/GenerateImageRequest.java
@@ -1,0 +1,49 @@
+package com.dfdt.delivery.domain.ai.presentation.dto.request;
+
+import com.dfdt.delivery.domain.ai.application.dto.GenerateImageCommand;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AspectRatio;
+import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+public record GenerateImageRequest(
+
+        UUID productId,         // nullable — productName과 둘 중 하나 필수 (UseCase에서 검증)
+
+        @Size(max = 120, message = "productName은 최대 120자까지 입력 가능합니다.")
+        String productName,     // nullable
+
+        @NotBlank(message = "prompt는 필수입니다.")
+        @Size(max = 500, message = "이미지 생성 prompt는 최대 500자까지 입력 가능합니다.")
+        String prompt,
+
+        AspectRatio aspectRatio,    // nullable — 기본값 SQUARE (UseCase에서 처리)
+
+        @Size(max = 50, message = "style은 최대 50자까지 입력 가능합니다.")
+        String style,               // nullable — 이미지 스타일 자유 텍스트 (예: "수채화", "사진 실사")
+
+        @NotNull(message = "includeText는 필수입니다.")
+        Boolean includeText,    // 이미지에 텍스트 오버레이 포함 여부
+
+        @Size(max = 50, message = "이미지 내 텍스트는 최대 50자까지 입력 가능합니다.")
+        String text             // includeText=true인 경우 UseCase에서 필수 검증
+
+) {
+    public GenerateImageCommand toCommand(UUID storeId, CustomUserDetails userDetails) {
+        return new GenerateImageCommand(
+                storeId,
+                userDetails.getUsername(),
+                userDetails.getRole(),
+                productId,
+                productName,
+                prompt,
+                aspectRatio,
+                style,
+                Boolean.TRUE.equals(includeText),
+                text
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/GenerateImageResponse.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/GenerateImageResponse.java
@@ -1,0 +1,19 @@
+package com.dfdt.delivery.domain.ai.presentation.dto.response;
+
+import com.dfdt.delivery.domain.ai.application.dto.GenerateImageResult;
+
+import java.util.UUID;
+
+public record GenerateImageResponse(
+        UUID aiLogId,
+        String imageData,  // base64 인코딩된 이미지 데이터
+        String mimeType    // e.g., "image/png"
+) {
+    public static GenerateImageResponse from(GenerateImageResult result) {
+        return new GenerateImageResponse(
+                result.aiLogId(),
+                result.imageData(),
+                result.mimeType()
+        );
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,6 +6,7 @@ ai:
   gemini:
     api-key: ${GEMINI_API_KEY}
     model: gemini-3.1-flash-lite-preview
+    image-model: imagen-4.0-fast-generate-001
     base-url: https://generativelanguage.googleapis.com
 
 springdoc:

--- a/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/CheckAiHealthUseCaseImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/CheckAiHealthUseCaseImplTest.java
@@ -23,7 +23,7 @@ class CheckAiHealthUseCaseImplTest {
 
     // GeminiProperties는 record(final class)라 Mockito로 mock 불가 → 실제 인스턴스 사용
     private static final GeminiProperties PROPERTIES =
-            new GeminiProperties("test-api-key", "gemini-2.0-flash", "https://test.googleapis.com");
+            new GeminiProperties("test-api-key", "gemini-2.0-flash", "https://test.googleapis.com", "gemini-2.0-flash-exp");
 
     @Mock
     private GeminiClient geminiClient;

--- a/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateImageUseCaseImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateImageUseCaseImplTest.java
@@ -1,0 +1,321 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.common.infrastructure.persistence.embedded.SoftDeleteAudit;
+import com.dfdt.delivery.domain.ai.application.dto.GenerateImageCommand;
+import com.dfdt.delivery.domain.ai.application.dto.GenerateImageResult;
+import com.dfdt.delivery.domain.ai.domain.client.GeneratedImageData;
+import com.dfdt.delivery.domain.ai.domain.client.ImageGenerationClient;
+import com.dfdt.delivery.domain.ai.domain.entity.AiLogEntity;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AspectRatio;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogRepository;
+import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.product.domain.repository.ProductRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GenerateImageUseCaseImpl 테스트")
+class GenerateImageUseCaseImplTest {
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private AiLogRepository aiLogRepository;
+
+    @Mock
+    private ImageGenerationClient imageGenerationClient;
+
+    @InjectMocks
+    private GenerateImageUseCaseImpl sut;
+
+    private UUID storeId;
+    private UUID productId;
+    private String requestedBy;
+
+    @BeforeEach
+    void setUp() {
+        storeId = UUID.randomUUID();
+        productId = UUID.randomUUID();
+        requestedBy = "owner123";
+    }
+
+    // ──────────────────────────────────────────────────
+    // 정상 케이스
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("정상 실행")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("productName만으로 이미지 생성 성공")
+        void shouldSucceedWithProductNameOnly() {
+            // given
+            Store mockStore = mockStore(requestedBy);
+            GeneratedImageData imageData = new GeneratedImageData("base64abc==", "image/png");
+
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+            given(imageGenerationClient.generate(any(), any())).willReturn(imageData);
+            given(aiLogRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            GenerateImageCommand command = new GenerateImageCommand(
+                    storeId, requestedBy, UserRole.OWNER,
+                    null, "황금 바삭치킨",
+                    "따뜻한 식당 배경으로 맛있게", null, null, false, null
+            );
+
+            // when
+            GenerateImageResult result = sut.execute(command);
+
+            // then
+            assertThat(result.imageData()).isEqualTo("base64abc==");
+            assertThat(result.mimeType()).isEqualTo("image/png");
+            then(aiLogRepository).should().save(any(AiLogEntity.class));
+        }
+
+        @Test
+        @DisplayName("includeText=true이면 text가 프롬프트에 포함된다")
+        void shouldIncludeTextInPromptWhenRequested() {
+            // given
+            Store mockStore = mockStore(requestedBy);
+            GeneratedImageData imageData = new GeneratedImageData("imagedata==", "image/png");
+
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+            given(imageGenerationClient.generate(contains("치킨"), any())).willReturn(imageData);
+            given(aiLogRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            GenerateImageCommand command = new GenerateImageCommand(
+                    storeId, requestedBy, UserRole.OWNER,
+                    null, "치킨",
+                    "배경은 노란색", AspectRatio.LANDSCAPE, "수채화", true, "치킨"
+            );
+
+            // when & then
+            assertThatCode(() -> sut.execute(command)).doesNotThrowAnyException();
+            then(imageGenerationClient).should().generate(contains("치킨"), any());
+        }
+
+        @Test
+        @DisplayName("productId가 있으면 product.getName()을 프롬프트에 사용한다")
+        void shouldUseProductNameFromProductEntity() {
+            // given
+            Store mockStore = mockStore(requestedBy);
+            Product mockProduct = mockProduct("황금 바삭치킨", false);
+            GeneratedImageData imageData = new GeneratedImageData("imgdata==", "image/jpeg");
+
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+            given(productRepository.findByProductIdAndStoreId(productId, storeId))
+                    .willReturn(Optional.of(mockProduct));
+            given(imageGenerationClient.generate(contains("황금 바삭치킨"), any())).willReturn(imageData);
+            given(aiLogRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            GenerateImageCommand command = new GenerateImageCommand(
+                    storeId, requestedBy, UserRole.OWNER,
+                    productId, null,
+                    "바삭하게 보이도록", AspectRatio.SQUARE, null, false, null
+            );
+
+            // when
+            sut.execute(command);
+
+            // then: 상품명이 프롬프트에 포함되어 API 호출됨
+            then(imageGenerationClient).should().generate(contains("황금 바삭치킨"), any());
+        }
+
+        @Test
+        @DisplayName("MASTER 역할은 소유권 체크 없이 통과한다")
+        void masterRoleShouldSkipOwnershipCheck() {
+            // given
+            Store mockStore = mockStore("otherOwner");
+            GeneratedImageData imageData = new GeneratedImageData("data==", "image/png");
+
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+            given(imageGenerationClient.generate(any(), any())).willReturn(imageData);
+            given(aiLogRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            GenerateImageCommand command = new GenerateImageCommand(
+                    storeId, "masterUser", UserRole.MASTER,
+                    null, "치킨",
+                    "맛있게", null, null, false, null
+            );
+
+            // when & then
+            assertThatCode(() -> sut.execute(command)).doesNotThrowAnyException();
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 입력 검증 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("입력 검증 예외")
+    class ValidationExceptionTests {
+
+        @Test
+        @DisplayName("productId와 productName 모두 없으면 PRODUCT_IDENTIFIER_REQUIRED")
+        void shouldThrowWhenBothProductIdentifiersMissing() {
+            // given
+            Store mockStore = mockStore(requestedBy);
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+
+            GenerateImageCommand command = new GenerateImageCommand(
+                    storeId, requestedBy, UserRole.OWNER,
+                    null, null, "맛있게", null, null, false, null  // productId, productName 모두 null
+            );
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.PRODUCT_IDENTIFIER_REQUIRED));
+        }
+
+        @Test
+        @DisplayName("includeText=true인데 text가 없으면 INCLUDE_TEXT_REQUIRED")
+        void shouldThrowWhenTextMissingWithIncludeTextTrue() {
+            // given
+            Store mockStore = mockStore(requestedBy);
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+
+            GenerateImageCommand command = new GenerateImageCommand(
+                    storeId, requestedBy, UserRole.OWNER,
+                    null, "치킨",
+                    "맛있게", null, null, true, null  // includeText=true but text=null
+            );
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.INCLUDE_TEXT_REQUIRED));
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // Store / 소유권 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("Store 관련 예외")
+    class StoreExceptionTests {
+
+        @Test
+        @DisplayName("존재하지 않는 storeId → STORE_NOT_FOUND")
+        void shouldThrowWhenStoreNotFound() {
+            // given
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.empty());
+
+            GenerateImageCommand command = new GenerateImageCommand(
+                    storeId, requestedBy, UserRole.OWNER,
+                    null, "치킨", "맛있게", null, null, false, null
+            );
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("OWNER가 본인 소유가 아닌 가게 접근 → STORE_ACCESS_DENIED")
+        void shouldThrowWhenOwnerAccessesDifferentStore() {
+            // given
+            Store mockStore = mockStore("anotherOwner");
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+
+            GenerateImageCommand command = new GenerateImageCommand(
+                    storeId, requestedBy, UserRole.OWNER,
+                    null, "치킨", "맛있게", null, null, false, null
+            );
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_ACCESS_DENIED));
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 이미지 생성 API 실패
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("ImageGenerationClient 실패 처리")
+    class ImageClientFailureTests {
+
+        @Test
+        @DisplayName("이미지 생성 실패 시 실패 로그를 저장하고 예외를 다시 던진다")
+        void shouldSaveFailureLogAndRethrowOnClientFailure() {
+            // given
+            Store mockStore = mockStore(requestedBy);
+            BusinessException clientException = new BusinessException(AiErrorCode.EXTERNAL_AI_CALL_FAILED);
+
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+            given(imageGenerationClient.generate(any(), any())).willThrow(clientException);
+            given(aiLogRepository.save(any())).willAnswer(inv -> inv.getArgument(0));
+
+            GenerateImageCommand command = new GenerateImageCommand(
+                    storeId, requestedBy, UserRole.OWNER,
+                    null, "치킨", "맛있게", null, null, false, null
+            );
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.EXTERNAL_AI_CALL_FAILED));
+
+            then(aiLogRepository).should().save(any(AiLogEntity.class));
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 헬퍼 메서드
+    // ──────────────────────────────────────────────────
+
+    private Store mockStore(String ownerUsername) {
+        User mockUser = mock(User.class);
+        lenient().when(mockUser.getUsername()).thenReturn(ownerUsername);
+
+        Store mockStore = mock(Store.class);
+        lenient().when(mockStore.getUser()).thenReturn(mockUser);
+
+        return mockStore;
+    }
+
+    private Product mockProduct(String productName, boolean isDeleted) {
+        SoftDeleteAudit softDeleteAudit = mock(SoftDeleteAudit.class);
+        given(softDeleteAudit.isDeleted()).willReturn(isDeleted);
+
+        Product mockProduct = mock(Product.class);
+        given(mockProduct.getSoftDeleteAudit()).willReturn(softDeleteAudit);
+        if (!isDeleted) {
+            given(mockProduct.getName()).willReturn(productName);
+        }
+
+        return mockProduct;
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiImageWebClientTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiImageWebClientTest.java
@@ -1,6 +1,7 @@
 package com.dfdt.delivery.domain.ai.infrastructure.client;
 
 import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.domain.client.GeneratedImageData;
 import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
 import com.dfdt.delivery.domain.ai.infrastructure.config.GeminiProperties;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,8 +13,8 @@ import org.springframework.web.client.RestClient;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
-@DisplayName("GeminiWebClient 테스트")
-class GeminiWebClientTest {
+@DisplayName("GeminiImageWebClient 테스트")
+class GeminiImageWebClientTest {
 
     private GeminiProperties properties;
 
@@ -23,52 +24,72 @@ class GeminiWebClientTest {
                 "test-api-key",
                 "gemini-2.0-flash",
                 "https://generativelanguage.googleapis.com",
-                "gemini-2.0-flash-exp"
+                "imagen-4.0-generate-001"
         );
     }
 
     // ──────────────────────────────────────────────────
-    // parseText() 단위 테스트 — 파싱/검증 핵심 로직
+    // parseImage() 단위 테스트 — 파싱/검증 핵심 로직
     // ──────────────────────────────────────────────────
     @Nested
-    @DisplayName("응답 JSON 파싱 (parseText)")
-    class ParseTextTests {
+    @DisplayName("응답 JSON 파싱 (parseImage)")
+    class ParseImageTests {
 
-        private GeminiWebClient sut;
+        private GeminiImageWebClient sut;
 
         @BeforeEach
         void setUp() {
-            // parseText()는 RestClient를 사용하지 않으므로 mock 전달
-            sut = new GeminiWebClient(mock(RestClient.class), properties);
+            sut = new GeminiImageWebClient(mock(RestClient.class), properties);
         }
 
         @Test
-        @DisplayName("정상 응답 JSON에서 텍스트를 추출한다")
-        void shouldExtractTextFromValidJson() {
-            // given
+        @DisplayName("정상 응답 JSON에서 base64 이미지 데이터를 추출한다")
+        void shouldExtractImageDataFromValidJson() {
+            // given — Imagen API 응답 구조: predictions[0].bytesBase64Encoded + mimeType
             String responseJson = """
                     {
-                      "candidates": [
+                      "predictions": [
                         {
-                          "content": {
-                            "parts": [{"text": "맛있는 황금 치킨입니다!"}]
-                          }
+                          "bytesBase64Encoded": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ",
+                          "mimeType": "image/jpeg"
                         }
                       ]
                     }
                     """;
 
             // when
-            String result = sut.parseText(responseJson);
+            GeneratedImageData result = sut.parseImage(responseJson);
 
             // then
-            assertThat(result).isEqualTo("맛있는 황금 치킨입니다!");
+            assertThat(result.base64Data()).isEqualTo("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJ");
+            assertThat(result.mimeType()).isEqualTo("image/jpeg");
         }
 
         @Test
-        @DisplayName("candidates 배열이 비어 있으면 EXTERNAL_AI_EMPTY_RESPONSE")
-        void shouldThrowWhenCandidatesEmpty() {
-            assertThatThrownBy(() -> sut.parseText("{\"candidates\": []}"))
+        @DisplayName("mimeType이 없으면 기본값 image/jpeg를 사용한다")
+        void shouldDefaultToImageJpegWhenMimeTypeAbsent() {
+            // given
+            String responseJson = """
+                    {
+                      "predictions": [
+                        {
+                          "bytesBase64Encoded": "base64data"
+                        }
+                      ]
+                    }
+                    """;
+
+            // when
+            GeneratedImageData result = sut.parseImage(responseJson);
+
+            // then
+            assertThat(result.mimeType()).isEqualTo("image/jpeg");
+        }
+
+        @Test
+        @DisplayName("predictions 배열이 비어 있으면 EXTERNAL_AI_EMPTY_RESPONSE")
+        void shouldThrowWhenPredictionsEmpty() {
+            assertThatThrownBy(() -> sut.parseImage("{\"predictions\": []}"))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(AiErrorCode.EXTERNAL_AI_EMPTY_RESPONSE));
@@ -77,16 +98,27 @@ class GeminiWebClientTest {
         @Test
         @DisplayName("응답 자체가 null이면 EXTERNAL_AI_EMPTY_RESPONSE")
         void shouldThrowWhenResponseIsNull() {
-            assertThatThrownBy(() -> sut.parseText(null))
+            assertThatThrownBy(() -> sut.parseImage(null))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(AiErrorCode.EXTERNAL_AI_EMPTY_RESPONSE));
         }
 
         @Test
-        @DisplayName("응답이 빈 문자열이면 EXTERNAL_AI_EMPTY_RESPONSE")
-        void shouldThrowWhenResponseIsBlank() {
-            assertThatThrownBy(() -> sut.parseText("   "))
+        @DisplayName("bytesBase64Encoded가 없으면 EXTERNAL_AI_EMPTY_RESPONSE")
+        void shouldThrowWhenImageDataBlank() {
+            // given — predictions는 있지만 bytesBase64Encoded 필드 없음
+            String responseJson = """
+                    {
+                      "predictions": [
+                        {
+                          "mimeType": "image/jpeg"
+                        }
+                      ]
+                    }
+                    """;
+
+            assertThatThrownBy(() -> sut.parseImage(responseJson))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(AiErrorCode.EXTERNAL_AI_EMPTY_RESPONSE));
@@ -100,12 +132,8 @@ class GeminiWebClientTest {
     @DisplayName("HTTP 호출 (generate)")
     class GenerateTests {
 
-        /**
-         * executeHttpCall()을 오버라이드한 테스트용 서브클래스.
-         * RestClient 체인을 mock하지 않고도 generate()의 흐름을 검증할 수 있습니다.
-         */
-        private GeminiWebClient stubWith(String returnValue) {
-            return new GeminiWebClient(mock(RestClient.class), properties) {
+        private GeminiImageWebClient stubWith(String returnValue) {
+            return new GeminiImageWebClient(mock(RestClient.class), properties) {
                 @Override
                 protected String executeHttpCall(String url, Object body) {
                     return returnValue;
@@ -113,8 +141,8 @@ class GeminiWebClientTest {
             };
         }
 
-        private GeminiWebClient throwingWith(RuntimeException ex) {
-            return new GeminiWebClient(mock(RestClient.class), properties) {
+        private GeminiImageWebClient throwingWith(RuntimeException ex) {
+            return new GeminiImageWebClient(mock(RestClient.class), properties) {
                 @Override
                 protected String executeHttpCall(String url, Object body) {
                     throw ex;
@@ -123,33 +151,37 @@ class GeminiWebClientTest {
         }
 
         @Test
-        @DisplayName("HTTP 호출 성공 시 parseText를 거쳐 텍스트를 반환한다")
-        void shouldReturnParsedTextOnSuccess() {
-            // given
+        @DisplayName("HTTP 호출 성공 시 parseImage를 거쳐 이미지 데이터를 반환한다")
+        void shouldReturnParsedImageOnSuccess() {
+            // given — Imagen API 응답 구조
             String responseJson = """
                     {
-                      "candidates": [
-                        {"content": {"parts": [{"text": "바삭한 치킨!"}]}}
+                      "predictions": [
+                        {
+                          "bytesBase64Encoded": "abc123base64==",
+                          "mimeType": "image/jpeg"
+                        }
                       ]
                     }
                     """;
-            GeminiWebClient sut = stubWith(responseJson);
+            GeminiImageWebClient sut = stubWith(responseJson);
 
             // when
-            String result = sut.generate("치킨 설명");
+            GeneratedImageData result = sut.generate("음식 사진 생성", "1:1");
 
             // then
-            assertThat(result).isEqualTo("바삭한 치킨!");
+            assertThat(result.base64Data()).isEqualTo("abc123base64==");
+            assertThat(result.mimeType()).isEqualTo("image/jpeg");
         }
 
         @Test
         @DisplayName("HTTP 호출에서 RuntimeException 발생 시 EXTERNAL_AI_CALL_FAILED")
         void shouldWrapRuntimeExceptionAsCallFailed() {
             // given
-            GeminiWebClient sut = throwingWith(new RuntimeException("Connection refused"));
+            GeminiImageWebClient sut = throwingWith(new RuntimeException("Connection refused"));
 
             // when & then
-            assertThatThrownBy(() -> sut.generate("치킨 설명"))
+            assertThatThrownBy(() -> sut.generate("음식 사진 생성", "1:1"))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(AiErrorCode.EXTERNAL_AI_CALL_FAILED));
@@ -158,12 +190,12 @@ class GeminiWebClientTest {
         @Test
         @DisplayName("HTTP 호출에서 BusinessException 발생 시 그대로 rethrow된다")
         void shouldRethrowBusinessException() {
-            // given - BusinessException은 포장 없이 그대로 던져진다
+            // given
             BusinessException original = new BusinessException(AiErrorCode.EXTERNAL_AI_TIMEOUT);
-            GeminiWebClient sut = throwingWith(original);
+            GeminiImageWebClient sut = throwingWith(original);
 
             // when & then
-            assertThatThrownBy(() -> sut.generate("치킨 설명"))
+            assertThatThrownBy(() -> sut.generate("음식 사진 생성", "1:1"))
                     .isInstanceOf(BusinessException.class)
                     .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                             .isEqualTo(AiErrorCode.EXTERNAL_AI_TIMEOUT));

--- a/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
@@ -7,10 +7,12 @@ import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
 import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.AiPromptRulesResult;
+import com.dfdt.delivery.domain.ai.application.dto.GenerateImageResult;
 import com.dfdt.delivery.domain.ai.application.dto.RetryDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.CheckAiHealthUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.GenerateImageUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetAiLogDetailUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetPromptRulesUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.RetryDescriptionUseCase;
@@ -90,6 +92,9 @@ class AiDescriptionControllerTest {
 
     @MockBean
     private RetryDescriptionUseCase retryDescriptionUseCase;
+
+    @MockBean
+    private GenerateImageUseCase generateImageUseCase;
 
     @MockBean
     private com.dfdt.delivery.domain.auth.infrastructure.jwt.JwtProvider jwtProvider;
@@ -861,6 +866,172 @@ class AiDescriptionControllerTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestBody)))
                     .andExpect(status().isBadRequest());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // API-AI-301: AI 음식 이미지 생성
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AI 음식 이미지 생성 (API-AI-301)")
+    class GenerateImageTests {
+
+        @Test
+        @DisplayName("OWNER가 유효한 요청을 보내면 201과 이미지 데이터를 반환한다")
+        void ownerShouldReturn201WithImageData() throws Exception {
+            // given
+            UUID aiLogId = UUID.randomUUID();
+            GenerateImageResult mockResult = new GenerateImageResult(
+                    aiLogId, "base64imagedata==", "image/png"
+            );
+            given(generateImageUseCase.execute(any())).willReturn(mockResult);
+
+            Map<String, Object> requestBody = Map.of(
+                    "productName", "황금 바삭치킨",
+                    "prompt", "따뜻한 식당 배경으로 맛있게",
+                    "includeText", false
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/images/preview", storeId)
+                            .with(user(ownerDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestBody)))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.status").value(201))
+                    .andExpect(jsonPath("$.data.aiLogId").value(aiLogId.toString()))
+                    .andExpect(jsonPath("$.data.imageData").value("base64imagedata=="))
+                    .andExpect(jsonPath("$.data.mimeType").value("image/png"));
+        }
+
+        @Test
+        @DisplayName("MASTER도 201을 반환한다")
+        void masterShouldReturn201() throws Exception {
+            // given
+            given(generateImageUseCase.execute(any())).willReturn(
+                    new GenerateImageResult(UUID.randomUUID(), "data==", "image/png")
+            );
+
+            Map<String, Object> requestBody = Map.of(
+                    "productName", "치킨",
+                    "prompt", "맛있게 보이게",
+                    "includeText", false
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/images/preview", storeId)
+                            .with(user(masterDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestBody)))
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        @DisplayName("prompt가 없으면 400을 반환한다")
+        void shouldReturn400WhenPromptMissing() throws Exception {
+            Map<String, Object> requestBody = Map.of(
+                    "productName", "치킨",
+                    "includeText", false
+                    // prompt 없음
+            );
+
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/images/preview", storeId)
+                            .with(user(ownerDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestBody)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("prompt가 500자를 초과하면 400을 반환한다")
+        void shouldReturn400WhenPromptTooLong() throws Exception {
+            Map<String, Object> requestBody = Map.of(
+                    "productName", "치킨",
+                    "prompt", "a".repeat(501),
+                    "includeText", false
+            );
+
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/images/preview", storeId)
+                            .with(user(ownerDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestBody)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 역할은 403을 반환한다")
+        void customerShouldReturn403() throws Exception {
+            User customer = User.builder()
+                    .username("customer1").name("고객").password("pw").role(UserRole.CUSTOMER).build();
+            CustomUserDetails customerDetails = new CustomUserDetails(customer);
+
+            Map<String, Object> requestBody = Map.of(
+                    "productName", "치킨",
+                    "prompt", "맛있게",
+                    "includeText", false
+            );
+
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/images/preview", storeId)
+                            .with(user(customerDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestBody)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("aspectRatio와 style을 포함한 요청도 201을 반환한다")
+        void shouldReturn201WithAspectRatioAndStyle() throws Exception {
+            // given
+            given(generateImageUseCase.execute(any())).willReturn(
+                    new GenerateImageResult(UUID.randomUUID(), "data==", "image/png")
+            );
+
+            Map<String, Object> requestBody = Map.of(
+                    "productName", "황금 바삭치킨",
+                    "prompt", "따뜻한 식당 배경으로",
+                    "aspectRatio", "LANDSCAPE",
+                    "style", "수채화",
+                    "includeText", false
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/images/preview", storeId)
+                            .with(user(ownerDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestBody)))
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        @DisplayName("style이 50자를 초과하면 400을 반환한다")
+        void shouldReturn400WhenStyleTooLong() throws Exception {
+            Map<String, Object> requestBody = Map.of(
+                    "productName", "치킨",
+                    "prompt", "맛있게",
+                    "style", "a".repeat(51),
+                    "includeText", false
+            );
+
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/images/preview", storeId)
+                            .with(user(ownerDetails))
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestBody)))
+                    .andExpect(status().isBadRequest());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 요청은 4xx를 반환한다")
+        void unauthenticatedShouldReturn4xx() throws Exception {
+            Map<String, Object> requestBody = Map.of(
+                    "productName", "치킨",
+                    "prompt", "맛있게",
+                    "includeText", false
+            );
+
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/images/preview", storeId)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestBody)))
+                    .andExpect(status().is4xxClientError());
         }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

## 📌 작업 내용
  [API-AI-301] 이미지 생성 AI (PoC) — Imagen 4 Fast 연동                  
                                                                          
  음식 상품 이미지를 AI로 생성하는 기능을 구현했습니다. Google Imagen 4
  API를 통해 상품명, 프롬프트, 비율, 스타일을 입력받아 base64 이미지를    
  반환합니다.  

## ✅ 주요 변경 사항
  신규 파일                                                               
  - ImageGenerationClient (domain/client) — 이미지 생성 외부 AI 호출
  인터페이스
  - GeneratedImageData (domain/client) — base64 이미지 데이터 + mimeType
  VO
  - GeminiImageWebClient (infrastructure/client) — Imagen 4 API 구현체
  (:predict 엔드포인트)
  - AspectRatio (domain/entity/enums) — 이미지 비율 Enum (SQUARE,
  LANDSCAPE, PORTRAIT, STANDARD)
  - GenerateImageCommand / GenerateImageResult / GenerateImageUseCase /
  GenerateImageUseCaseImpl
  - GenerateImageRequest / GenerateImageResponse — Controller ↔ UseCase
  입출력 DTO

  수정 파일
  - GeminiProperties — imageModel 필드 추가 (텍스트 모델과 이미지 모델
  분리)
  - application.yaml — image-model: imagen-4.0-generate-001 추가
  - AiDescriptionController — POST
  /api/v1/ai/stores/{storeId}/images/preview 엔드포인트 추가


## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인
- [x] 예외 케이스 확인 (해당 시)

### 확인 방법 (선택)
전체 AI 도메인 테스트

총 25개 이상 테스트 통과

실행 명령어

./gradlew test --tests "com.dfdt.delivery.domain.ai.*"


Layer | Test Class | Cases | 주요 검증
-- | -- | -- | --
Infrastructure | GeminiImageWebClientTest | 8 | HTTP 호출 및 응답 파싱
Application | GenerateImageUseCaseImplTest | 9 | 이미지 생성 로직 / 예외 처리
Presentation | AiDescriptionControllerTest | 8 | API 요청 검증 / 권한


## ⚠️ 영향 범위 (해당 시 체크)
- [x] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정

## 👀 리뷰 포인트 (선택)
  ---
  리뷰 포인트

  1. PoC 범위 확인 — 현재 이미지 데이터는 AI 로그(responseText)에 base64
  문자열로 저장됩니다. 실서비스 전환 시 S3 등 스토리지 업로드 후 URL
  반환으로 변경이 필요합니다.
  2. aspectRatio 기본값 처리 위치 — UseCase 레이어에서 null → SQUARE
  처리합니다. Controller에서 처리하는 방식도 가능하므로 팀 컨벤션에 맞게
  조정할 수 있습니다.
  3. Imagen API 모델명 고정 — application.yaml의 image-model
  값(imagen-4.0-generate-001)은 Google의 정식 GA 버전 출시 시 업데이트가
  필요할 수 있습니다.
  4. style 파라미터 자유 텍스트 — "수채화", "사진 실사" 등 경우의 수가
  많아 Enum 대신 max 50자 문자열로 설계했습니다. 향후 자주 쓰이는 스타일을
   Enum으로 표준화할 수 있습니다.

