### PR TITLE
feat: 호출 통계 조회, 상품 설명 롤백 기능 구현

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/AiStatsQuery.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/AiStatsQuery.java
@@ -1,0 +1,17 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 가게별/기간별 AI 호출 통계 UseCase 입력 쿼리.
+ */
+public record AiStatsQuery(
+        UUID storeId,
+        OffsetDateTime fromDateTime,   // nullable — 시작 시간 (포함)
+        OffsetDateTime toDateTime,     // nullable — 종료 시간 (포함)
+        AiRequestType requestType      // nullable — 요청 타입 필터
+) {
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/AiStatsResult.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/AiStatsResult.java
@@ -1,0 +1,19 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 가게별/기간별 AI 호출 통계 결과.
+ */
+public record AiStatsResult(
+        UUID storeId,
+        long totalCount,           // 총 AI 호출 수
+        long successCount,         // 성공 수
+        long failureCount,         // 실패 수
+        double successRate,        // 성공률 (%, 소수점 1자리)
+        Long avgResponseTimeMs,    // 평균 응답 시간 (ms) — 성공 로그 기준, nullable
+        OffsetDateTime fromDateTime,
+        OffsetDateTime toDateTime
+) {
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/RollbackDescriptionCommand.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/RollbackDescriptionCommand.java
@@ -1,0 +1,16 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+
+import java.util.UUID;
+
+/**
+ * AI 설명 원복 UseCase 입력 커맨드.
+ */
+public record RollbackDescriptionCommand(
+        UUID storeId,
+        UUID aiLogId,
+        String requestedBy,
+        UserRole requestedByRole
+) {
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/dto/RollbackDescriptionResult.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/dto/RollbackDescriptionResult.java
@@ -1,0 +1,15 @@
+package com.dfdt.delivery.domain.ai.application.dto;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * AI 설명 원복 결과.
+ */
+public record RollbackDescriptionResult(
+        UUID aiLogId,
+        UUID productId,
+        String restoredDescription,   // 복원된 설명 (apply 이전 값), nullable
+        OffsetDateTime rolledBackAt
+) {
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateDescriptionUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateDescriptionUseCaseImpl.java
@@ -74,9 +74,12 @@ public class GenerateDescriptionUseCaseImpl implements GenerateDescriptionUseCas
 
         // 5. Gemini API 호출 — 실패 시 실패 로그 저장 후 예외 rethrow
         String rawResponse;
+        String modelName = geminiClient.getModelName();
+        long startMs = System.currentTimeMillis();
         try {
             rawResponse = geminiClient.generate(finalPrompt);
         } catch (BusinessException e) {
+            int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
             aiLogRepository.save(AiLogEntity.failureProductDescription(
                     command.storeId(),
                     command.productId(),
@@ -85,14 +88,15 @@ public class GenerateDescriptionUseCaseImpl implements GenerateDescriptionUseCas
                     finalPrompt,
                     e.getErrorCode().getErrorCode(),
                     e.getMessage(),
-                    null,           // modelName: Round 3에서 추가
-                    null,           // responseTimeMs: Round 3에서 추가
+                    modelName,
+                    responseTimeMs,
                     null,           // sourceAiLogId: 재실행 시 사용
                     toneSnapshot,
                     keywordsSnapshot
             ));
             throw e;
         }
+        int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
 
         // 6. 응답 후처리 (50자 trim)
         String responseText = aiPromptPolicy.trimResponse(rawResponse);
@@ -105,8 +109,8 @@ public class GenerateDescriptionUseCaseImpl implements GenerateDescriptionUseCas
                 command.inputPrompt(),
                 finalPrompt,
                 responseText,
-                null,           // modelName: Round 3에서 추가
-                null,           // responseTimeMs: Round 3에서 추가
+                modelName,
+                responseTimeMs,
                 null,           // sourceAiLogId: 재실행 시 사용
                 toneSnapshot,
                 keywordsSnapshot

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateImageUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateImageUseCaseImpl.java
@@ -73,9 +73,12 @@ public class GenerateImageUseCaseImpl implements GenerateImageUseCase {
 
         // 8. 이미지 생성 API 호출 — 실패 시 실패 로그 저장 후 예외 rethrow
         GeneratedImageData imageData;
+        String modelName = imageGenerationClient.getModelName();
+        long startMs = System.currentTimeMillis();
         try {
             imageData = imageGenerationClient.generate(finalPrompt, aspectRatio.getRatio());
         } catch (BusinessException e) {
+            int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
             aiLogRepository.save(AiLogEntity.failureFoodImageGeneration(
                     command.storeId(),
                     command.productId(),
@@ -84,14 +87,15 @@ public class GenerateImageUseCaseImpl implements GenerateImageUseCase {
                     finalPrompt,
                     e.getErrorCode().getErrorCode(),
                     e.getMessage(),
-                    null,
-                    null,
+                    modelName,
+                    responseTimeMs,
                     null,
                     null,
                     null
             ));
             throw e;
         }
+        int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
 
         // 9. 성공 로그 저장 (imageData.base64Data를 responseText에 저장)
         AiLogEntity savedLog = aiLogRepository.save(AiLogEntity.successFoodImageGeneration(
@@ -101,8 +105,8 @@ public class GenerateImageUseCaseImpl implements GenerateImageUseCase {
                 command.prompt(),
                 finalPrompt,
                 imageData.base64Data(),
-                null,
-                null,
+                modelName,
+                responseTimeMs,
                 null,
                 null,
                 null

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiStatsUseCase.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiStatsUseCase.java
@@ -1,0 +1,9 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsQuery;
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsResult;
+
+public interface GetAiStatsUseCase {
+
+    AiStatsResult execute(AiStatsQuery query);
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiStatsUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiStatsUseCaseImpl.java
@@ -1,0 +1,43 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsQuery;
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsResult;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogCustomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+public class GetAiStatsUseCaseImpl implements GetAiStatsUseCase {
+
+    private final AiLogCustomRepository aiLogCustomRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public AiStatsResult execute(AiStatsQuery query) {
+
+        // 1. 날짜 범위 유효성 검증
+        if (query.fromDateTime() != null && query.toDateTime() != null) {
+            if (query.fromDateTime().isAfter(query.toDateTime())) {
+                throw new BusinessException(AiErrorCode.INVALID_DATE_RANGE);
+            }
+            long days = ChronoUnit.DAYS.between(query.fromDateTime(), query.toDateTime());
+            if (days > 90) {
+                throw new BusinessException(AiErrorCode.DATE_RANGE_EXCEEDED);
+            }
+        }
+
+        // 2. QueryDSL 집계 호출
+        return aiLogCustomRepository.getAiStats(
+                query.storeId(),
+                query.fromDateTime(),
+                query.toDateTime(),
+                query.requestType()
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/RetryDescriptionUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/RetryDescriptionUseCaseImpl.java
@@ -99,9 +99,12 @@ public class RetryDescriptionUseCaseImpl implements RetryDescriptionUseCase {
 
         // 10. Gemini API 호출 — 실패 시 실패 로그 저장 후 예외 rethrow
         String rawResponse;
+        String modelName = geminiClient.getModelName();
+        long startMs = System.currentTimeMillis();
         try {
             rawResponse = geminiClient.generate(finalPrompt);
         } catch (BusinessException e) {
+            int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
             aiLogRepository.save(AiLogEntity.failureProductDescription(
                     command.storeId(),
                     sourceLog.getProductId(),
@@ -110,14 +113,15 @@ public class RetryDescriptionUseCaseImpl implements RetryDescriptionUseCase {
                     finalPrompt,
                     e.getErrorCode().getErrorCode(),
                     e.getMessage(),
-                    null,
-                    null,
+                    modelName,
+                    responseTimeMs,
                     command.sourceAiLogId(),
                     toneSnapshot,
                     keywordsSnapshot
             ));
             throw e;
         }
+        int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
 
         // 11. 응답 후처리 (50자 trim)
         String responseText = aiPromptPolicy.trimResponse(rawResponse);
@@ -130,8 +134,8 @@ public class RetryDescriptionUseCaseImpl implements RetryDescriptionUseCase {
                 inputPrompt,
                 finalPrompt,
                 responseText,
-                null,
-                null,
+                modelName,
+                responseTimeMs,
                 command.sourceAiLogId(),
                 toneSnapshot,
                 keywordsSnapshot

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/RollbackDescriptionUseCase.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/RollbackDescriptionUseCase.java
@@ -1,0 +1,9 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.domain.ai.application.dto.RollbackDescriptionCommand;
+import com.dfdt.delivery.domain.ai.application.dto.RollbackDescriptionResult;
+
+public interface RollbackDescriptionUseCase {
+
+    RollbackDescriptionResult execute(RollbackDescriptionCommand command);
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/RollbackDescriptionUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/RollbackDescriptionUseCaseImpl.java
@@ -1,0 +1,75 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.RollbackDescriptionCommand;
+import com.dfdt.delivery.domain.ai.application.dto.RollbackDescriptionResult;
+import com.dfdt.delivery.domain.ai.domain.entity.AiLogEntity;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogRepository;
+import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.product.domain.repository.ProductRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RollbackDescriptionUseCaseImpl implements RollbackDescriptionUseCase {
+
+    private final AiLogRepository aiLogRepository;
+    private final StoreRepository storeRepository;
+    private final ProductRepository productRepository;
+
+    @Override
+    @Transactional
+    public RollbackDescriptionResult execute(RollbackDescriptionCommand command) {
+
+        // 1. AiLog 조회
+        AiLogEntity aiLog = aiLogRepository.findById(command.aiLogId())
+                .orElseThrow(() -> new BusinessException(AiErrorCode.AI_LOG_NOT_FOUND));
+
+        // 2. storeId 일치 검증 (URL 위변조 방지)
+        if (!aiLog.getStoreId().equals(command.storeId())) {
+            throw new BusinessException(AiErrorCode.STORE_NOT_FOUND);
+        }
+
+        // 3. OWNER 권한: 본인 가게인지 소유권 확인
+        if (command.requestedByRole() == UserRole.OWNER) {
+            Store store = storeRepository.findByStoreIdAndNotDeleted(command.storeId())
+                    .orElseThrow(() -> new BusinessException(AiErrorCode.STORE_NOT_FOUND));
+            if (!store.getUser().getUsername().equals(command.requestedBy())) {
+                throw new BusinessException(AiErrorCode.STORE_ACCESS_DENIED);
+            }
+        }
+
+        // 4. 아직 적용되지 않은 로그 → 원복 불가
+        if (!Boolean.TRUE.equals(aiLog.getIsApplied())) {
+            throw new BusinessException(AiErrorCode.NOT_YET_APPLIED);
+        }
+
+        // 5. 이미 원복된 로그 → 중복 원복 방지
+        if (aiLog.getRolledBackAt() != null) {
+            throw new BusinessException(AiErrorCode.ALREADY_ROLLED_BACK);
+        }
+
+        // 6. Product 조회
+        Product product = productRepository.findByProductIdAndStoreId(aiLog.getProductId(), command.storeId())
+                .orElseThrow(() -> new BusinessException(AiErrorCode.PRODUCT_NOT_FOUND));
+
+        // 7. apply 이전 설명으로 복원 (previousDescription이 null이면 설명 없음 상태로 복원)
+        product.restoreDescription(aiLog.getPreviousDescription(), command.requestedBy());
+
+        // 8. AiLog에 롤백 완료 기록
+        aiLog.rollback(command.requestedBy());
+
+        return new RollbackDescriptionResult(
+                aiLog.getAiLogId(),
+                aiLog.getProductId(),
+                aiLog.getPreviousDescription(),
+                aiLog.getRolledBackAt()
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/domain/client/GeminiClient.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/domain/client/GeminiClient.java
@@ -14,4 +14,9 @@ public interface GeminiClient {
      * @throws com.dfdt.delivery.common.exception.BusinessException AI 호출 실패 시
      */
     String generate(String prompt);
+
+    /**
+     * 현재 사용 중인 Gemini 모델명을 반환합니다.
+     */
+    String getModelName();
 }

--- a/src/main/java/com/dfdt/delivery/domain/ai/domain/client/ImageGenerationClient.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/domain/client/ImageGenerationClient.java
@@ -15,4 +15,9 @@ public interface ImageGenerationClient {
      * @throws com.dfdt.delivery.common.exception.BusinessException AI 호출 실패 시
      */
     GeneratedImageData generate(String prompt, String aspectRatio);
+
+    /**
+     * 현재 사용 중인 이미지 생성 모델명을 반환합니다.
+     */
+    String getModelName();
 }

--- a/src/main/java/com/dfdt/delivery/domain/ai/domain/enums/AiErrorCode.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/domain/enums/AiErrorCode.java
@@ -49,6 +49,8 @@ public enum AiErrorCode implements ErrorCode {
     STORE_PRODUCT_MISMATCH(409, "AI-4092", "storeId와 productId가 일치하지 않습니다."),
     PRODUCT_ID_REQUIRED_FOR_APPLY(409, "AI-4093", "productId가 없는 미리보기 로그는 적용할 수 없습니다."),
     RETRY_NOT_SUPPORTED_TYPE(409, "AI-4094", "해당 requestType은 재실행을 지원하지 않습니다."),
+    NOT_YET_APPLIED(409, "AI-4095", "적용되지 않은 AI 로그는 원복할 수 없습니다."),
+    ALREADY_ROLLED_BACK(409, "AI-4096", "이미 원복된 AI 로그입니다."),
 
     // 429 TOO MANY REQUESTS
     RATE_LIMIT_EXCEEDED(429, "AI-4291", "요청 횟수 한도를 초과했습니다. 잠시 후 다시 시도해 주세요."),

--- a/src/main/java/com/dfdt/delivery/domain/ai/domain/repository/AiLogCustomRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/domain/repository/AiLogCustomRepository.java
@@ -1,9 +1,12 @@
 package com.dfdt.delivery.domain.ai.domain.repository;
 
 import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsResult;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public interface AiLogCustomRepository {
@@ -15,4 +18,14 @@ public interface AiLogCustomRepository {
             Boolean isSuccess,
             Pageable pageable
     );
+
+    /**
+     * 가게별/기간별 AI 호출 통계를 집계합니다.
+     *
+     * @param storeId     가게 ID
+     * @param from        시작 시간 (nullable)
+     * @param to          종료 시간 (nullable)
+     * @param requestType 요청 타입 필터 (nullable)
+     */
+    AiStatsResult getAiStats(UUID storeId, OffsetDateTime from, OffsetDateTime to, AiRequestType requestType);
 }

--- a/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiImageWebClient.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiImageWebClient.java
@@ -33,6 +33,11 @@ public class GeminiImageWebClient implements ImageGenerationClient {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
+    public String getModelName() {
+        return properties.imageModel();
+    }
+
+    @Override
     public GeneratedImageData generate(String prompt, String aspectRatio) {
         String url = "/v1beta/models/" + properties.imageModel() + ":predict?key=" + properties.apiKey();
 

--- a/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiWebClient.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiWebClient.java
@@ -26,6 +26,11 @@ public class GeminiWebClient implements GeminiClient {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
+    public String getModelName() {
+        return properties.model();
+    }
+
+    @Override
     public String generate(String prompt) {
         String url = "/v1beta/models/" + properties.model() + ":generateContent?key=" + properties.apiKey();
 

--- a/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/persistence/AiLogCustomRepositoryImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/persistence/AiLogCustomRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.dfdt.delivery.domain.ai.infrastructure.persistence;
 
 import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsResult;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
 import com.dfdt.delivery.domain.ai.domain.repository.AiLogCustomRepository;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
@@ -14,8 +16,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static com.dfdt.delivery.domain.ai.domain.entity.QAiLogEntity.aiLogEntity;
@@ -73,6 +77,64 @@ public class AiLogCustomRepositoryImpl implements AiLogCustomRepository {
                 .fetchOne();
 
         return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    @Override
+    public AiStatsResult getAiStats(UUID storeId, OffsetDateTime from, OffsetDateTime to, AiRequestType requestType) {
+        // 기본 필터 조건 구성
+        List<BooleanExpression> baseConditions = new ArrayList<>();
+        baseConditions.add(aiLogEntity.storeId.eq(storeId));
+        baseConditions.add(aiLogEntity.softDeleteAudit.deletedAt.isNull());
+        baseConditions.add(fromDateTimeGoe(from));
+        baseConditions.add(toDateTimeLoe(to));
+        baseConditions.add(requestTypeEq(requestType));
+        BooleanExpression[] condArr = baseConditions.stream()
+                .filter(c -> c != null)
+                .toArray(BooleanExpression[]::new);
+
+        // 전체 호출 수
+        long totalCount = Optional.ofNullable(
+                queryFactory.select(aiLogEntity.count())
+                        .from(aiLogEntity)
+                        .where(condArr)
+                        .fetchOne()
+        ).orElse(0L);
+
+        // 성공 호출 수
+        long successCount = Optional.ofNullable(
+                queryFactory.select(aiLogEntity.count())
+                        .from(aiLogEntity)
+                        .where(condArr)
+                        .where(aiLogEntity.isSuccess.isTrue())
+                        .fetchOne()
+        ).orElse(0L);
+
+        // 성공 로그 기준 평균 응답 시간
+        Double avgMs = queryFactory.select(aiLogEntity.responseTimeMs.avg())
+                .from(aiLogEntity)
+                .where(condArr)
+                .where(aiLogEntity.isSuccess.isTrue())
+                .fetchOne();
+
+        double successRate = totalCount > 0
+                ? Math.round(successCount * 1000.0 / totalCount) / 10.0
+                : 0.0;
+        Long roundedAvgMs = avgMs != null ? Math.round(avgMs) : null;
+
+        return new AiStatsResult(storeId, totalCount, successCount, totalCount - successCount,
+                successRate, roundedAvgMs, from, to);
+    }
+
+    private BooleanExpression fromDateTimeGoe(OffsetDateTime from) {
+        return from == null ? null : aiLogEntity.createAudit.createdAt.goe(from);
+    }
+
+    private BooleanExpression toDateTimeLoe(OffsetDateTime to) {
+        return to == null ? null : aiLogEntity.createAudit.createdAt.loe(to);
+    }
+
+    private BooleanExpression requestTypeEq(AiRequestType requestType) {
+        return requestType == null ? null : aiLogEntity.requestType.eq(requestType);
     }
 
     private BooleanExpression productIdEq(UUID productId) {

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionController.java
@@ -6,24 +6,31 @@ import com.dfdt.delivery.domain.ai.application.dto.AiLogDetailResult;
 import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
 import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionCommand;
 import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsQuery;
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsResult;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionCommand;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.GetAiLogDetailQuery;
 import com.dfdt.delivery.domain.ai.application.dto.RetryDescriptionCommand;
 import com.dfdt.delivery.domain.ai.application.dto.RetryDescriptionResult;
+import com.dfdt.delivery.domain.ai.application.dto.RollbackDescriptionCommand;
+import com.dfdt.delivery.domain.ai.application.dto.RollbackDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.SearchAiLogsQuery;
 import com.dfdt.delivery.domain.ai.application.dto.SearchProductAiLogsQuery;
 import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.CheckAiHealthUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetAiLogDetailUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.GetAiStatsUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetPromptRulesUseCase;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateImageCommand;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateImageResult;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateImageUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.RetryDescriptionUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.RollbackDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchProductAiLogsUseCase;
+import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
 import com.dfdt.delivery.domain.ai.presentation.dto.request.GenerateDescriptionRequest;
 import com.dfdt.delivery.domain.ai.presentation.dto.request.GenerateImageRequest;
 import com.dfdt.delivery.domain.ai.presentation.dto.request.RetryDescriptionRequest;
@@ -31,10 +38,13 @@ import com.dfdt.delivery.domain.ai.presentation.dto.response.AiHealthResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiLogDetailResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiLogSummaryResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.AiPromptRulesResponse;
+import com.dfdt.delivery.domain.ai.presentation.dto.response.AiStatsResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.ApplyDescriptionResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.GenerateDescriptionResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.GenerateImageResponse;
 import com.dfdt.delivery.domain.ai.presentation.dto.response.RetryDescriptionResponse;
+import com.dfdt.delivery.domain.ai.presentation.dto.response.RollbackDescriptionResponse;
+import org.springframework.format.annotation.DateTimeFormat;
 import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +55,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @RestController
@@ -55,12 +66,14 @@ public class AiDescriptionController {
     private final GenerateDescriptionUseCase generateDescriptionUseCase;
     private final ApplyDescriptionUseCase applyDescriptionUseCase;
     private final RetryDescriptionUseCase retryDescriptionUseCase;
+    private final RollbackDescriptionUseCase rollbackDescriptionUseCase;
     private final GenerateImageUseCase generateImageUseCase;
     private final SearchAiLogsUseCase searchAiLogsUseCase;
     private final GetAiLogDetailUseCase getAiLogDetailUseCase;
     private final SearchProductAiLogsUseCase searchProductAiLogsUseCase;
     private final CheckAiHealthUseCase checkAiHealthUseCase;
     private final GetPromptRulesUseCase getPromptRulesUseCase;
+    private final GetAiStatsUseCase getAiStatsUseCase;
 
     /**
      * AI 연동 상태 확인 (API-AI-201)
@@ -292,6 +305,59 @@ public class AiDescriptionController {
                 HttpStatus.OK.value(),
                 "AI 상품 설명이 적용되었습니다.",
                 ApplyDescriptionResponse.from(result)
+        );
+    }
+
+    /**
+     * AI 설명 원복 (API-AI-205)
+     * POST /api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/rollback
+     *
+     * - OWNER: 본인 가게만 원복 가능 (UseCase에서 소유권 체크)
+     * - MASTER: 모든 가게 원복 가능
+     * - apply 완료된 로그의 previousDescription으로 상품 설명을 복원합니다.
+     */
+    @PostMapping("/stores/{storeId}/descriptions/{aiLogId}/rollback")
+    @PreAuthorize("hasAnyRole('OWNER', 'MASTER')")
+    public ResponseEntity<ApiResponseDto<RollbackDescriptionResponse>> rollbackDescription(
+            @PathVariable UUID storeId,
+            @PathVariable UUID aiLogId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        RollbackDescriptionCommand command = new RollbackDescriptionCommand(
+                storeId, aiLogId, userDetails.getUsername(), userDetails.getRole()
+        );
+        RollbackDescriptionResult result = rollbackDescriptionUseCase.execute(command);
+
+        return ApiResponseDto.success(
+                HttpStatus.OK.value(),
+                "AI 상품 설명이 원복되었습니다.",
+                RollbackDescriptionResponse.from(result)
+        );
+    }
+
+    /**
+     * 가게별/기간별 AI 호출 통계 (API-AI-204)
+     * GET /api/v1/ai/stores/{storeId}/stats
+     *
+     * - MASTER 전용
+     * - fromDateTime/toDateTime 생략 시 전체 기간 통계
+     * - 기간 범위는 최대 90일
+     */
+    @GetMapping("/stores/{storeId}/stats")
+    @PreAuthorize("hasRole('MASTER')")
+    public ResponseEntity<ApiResponseDto<AiStatsResponse>> getAiStats(
+            @PathVariable UUID storeId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime fromDateTime,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime toDateTime,
+            @RequestParam(required = false) AiRequestType requestType
+    ) {
+        AiStatsQuery query = new AiStatsQuery(storeId, fromDateTime, toDateTime, requestType);
+        AiStatsResult result = getAiStatsUseCase.execute(query);
+
+        return ApiResponseDto.success(
+                HttpStatus.OK.value(),
+                "AI 호출 통계를 조회했습니다.",
+                AiStatsResponse.from(result)
         );
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/AiStatsResponse.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/AiStatsResponse.java
@@ -1,0 +1,30 @@
+package com.dfdt.delivery.domain.ai.presentation.dto.response;
+
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsResult;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record AiStatsResponse(
+        UUID storeId,
+        long totalCount,
+        long successCount,
+        long failureCount,
+        double successRate,       // 0.0 ~ 100.0 (%, 소수점 1자리)
+        Long avgResponseTimeMs,   // nullable
+        OffsetDateTime fromDateTime,
+        OffsetDateTime toDateTime
+) {
+    public static AiStatsResponse from(AiStatsResult result) {
+        return new AiStatsResponse(
+                result.storeId(),
+                result.totalCount(),
+                result.successCount(),
+                result.failureCount(),
+                result.successRate(),
+                result.avgResponseTimeMs(),
+                result.fromDateTime(),
+                result.toDateTime()
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/RollbackDescriptionResponse.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/presentation/dto/response/RollbackDescriptionResponse.java
@@ -1,0 +1,22 @@
+package com.dfdt.delivery.domain.ai.presentation.dto.response;
+
+import com.dfdt.delivery.domain.ai.application.dto.RollbackDescriptionResult;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record RollbackDescriptionResponse(
+        UUID aiLogId,
+        UUID productId,
+        String restoredDescription,   // 복원된 설명, nullable
+        OffsetDateTime rolledBackAt
+) {
+    public static RollbackDescriptionResponse from(RollbackDescriptionResult result) {
+        return new RollbackDescriptionResponse(
+                result.aiLogId(),
+                result.productId(),
+                result.restoredDescription(),
+                result.rolledBackAt()
+        );
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/dfdt/delivery/domain/product/domain/entity/Product.java
@@ -89,6 +89,12 @@ public class Product {
         makeUpdateAudit(username);
     }
 
+    public void restoreDescription(String previousDescription, String username) {
+        this.description = previousDescription;
+        this.isAiDescription = false;
+        makeUpdateAudit(username);
+    }
+
     public void soldOut(String username) {
         makeUpdateAudit(username);
         this.isHidden = !this.isHidden;

--- a/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiStatsUseCaseImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/GetAiStatsUseCaseImplTest.java
@@ -1,0 +1,161 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsQuery;
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsResult;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogCustomRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GetAiStatsUseCaseImpl 테스트")
+class GetAiStatsUseCaseImplTest {
+
+    @Mock
+    private AiLogCustomRepository aiLogCustomRepository;
+
+    private GetAiStatsUseCaseImpl sut;
+
+    private UUID storeId;
+
+    @BeforeEach
+    void setUp() {
+        sut = new GetAiStatsUseCaseImpl(aiLogCustomRepository);
+        storeId = UUID.randomUUID();
+    }
+
+    // ──────────────────────────────────────────────────
+    // 정상 케이스
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("정상 요청")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("날짜 조건 없이 전체 기간 통계를 반환한다")
+        void shouldReturnStatsWithoutDateRange() {
+            // given
+            AiStatsResult mockResult = new AiStatsResult(storeId, 10L, 8L, 2L, 80.0, 350L, null, null);
+            given(aiLogCustomRepository.getAiStats(eq(storeId), isNull(), isNull(), isNull()))
+                    .willReturn(mockResult);
+
+            AiStatsQuery query = new AiStatsQuery(storeId, null, null, null);
+
+            // when
+            AiStatsResult result = sut.execute(query);
+
+            // then
+            assertThat(result.totalCount()).isEqualTo(10L);
+            assertThat(result.successCount()).isEqualTo(8L);
+            assertThat(result.failureCount()).isEqualTo(2L);
+            assertThat(result.successRate()).isEqualTo(80.0);
+            assertThat(result.avgResponseTimeMs()).isEqualTo(350L);
+        }
+
+        @Test
+        @DisplayName("날짜 범위를 지정해도 정상 반환한다")
+        void shouldReturnStatsWithDateRange() {
+            // given
+            OffsetDateTime from = OffsetDateTime.now().minusDays(7);
+            OffsetDateTime to = OffsetDateTime.now();
+            AiStatsResult mockResult = new AiStatsResult(storeId, 5L, 5L, 0L, 100.0, 200L, from, to);
+            given(aiLogCustomRepository.getAiStats(eq(storeId), eq(from), eq(to), isNull()))
+                    .willReturn(mockResult);
+
+            AiStatsQuery query = new AiStatsQuery(storeId, from, to, null);
+
+            // when
+            AiStatsResult result = sut.execute(query);
+
+            // then
+            assertThat(result.successRate()).isEqualTo(100.0);
+            assertThat(result.fromDateTime()).isEqualTo(from);
+        }
+
+        @Test
+        @DisplayName("AI 호출이 없으면 totalCount=0, successRate=0.0을 반환한다")
+        void shouldReturnZeroStatsWhenNoLogs() {
+            // given
+            AiStatsResult mockResult = new AiStatsResult(storeId, 0L, 0L, 0L, 0.0, null, null, null);
+            given(aiLogCustomRepository.getAiStats(any(), any(), any(), any())).willReturn(mockResult);
+
+            AiStatsQuery query = new AiStatsQuery(storeId, null, null, null);
+
+            // when
+            AiStatsResult result = sut.execute(query);
+
+            // then
+            assertThat(result.totalCount()).isEqualTo(0L);
+            assertThat(result.successRate()).isEqualTo(0.0);
+            assertThat(result.avgResponseTimeMs()).isNull();
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 날짜 범위 검증
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("날짜 범위 검증 예외")
+    class DateRangeValidationTests {
+
+        @Test
+        @DisplayName("fromDateTime이 toDateTime보다 이후면 INVALID_DATE_RANGE")
+        void shouldThrowWhenFromAfterTo() {
+            // given
+            OffsetDateTime from = OffsetDateTime.now();
+            OffsetDateTime to = from.minusDays(1);
+
+            AiStatsQuery query = new AiStatsQuery(storeId, from, to, null);
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.INVALID_DATE_RANGE));
+        }
+
+        @Test
+        @DisplayName("날짜 범위가 90일을 초과하면 DATE_RANGE_EXCEEDED")
+        void shouldThrowWhenRangeExceeds90Days() {
+            // given
+            OffsetDateTime from = OffsetDateTime.now().minusDays(91);
+            OffsetDateTime to = OffsetDateTime.now();
+
+            AiStatsQuery query = new AiStatsQuery(storeId, from, to, null);
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(query))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.DATE_RANGE_EXCEEDED));
+        }
+
+        @Test
+        @DisplayName("날짜 범위가 정확히 90일이면 통과한다")
+        void shouldPassWhenRangeIsExactly90Days() {
+            // given
+            OffsetDateTime from = OffsetDateTime.now().minusDays(90);
+            OffsetDateTime to = OffsetDateTime.now();
+            AiStatsResult mockResult = new AiStatsResult(storeId, 0L, 0L, 0L, 0.0, null, from, to);
+            given(aiLogCustomRepository.getAiStats(any(), any(), any(), any())).willReturn(mockResult);
+
+            AiStatsQuery query = new AiStatsQuery(storeId, from, to, null);
+
+            // when & then
+            assertThatCode(() -> sut.execute(query)).doesNotThrowAnyException();
+        }
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/RollbackDescriptionUseCaseImplTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/application/usecase/RollbackDescriptionUseCaseImplTest.java
@@ -1,0 +1,270 @@
+package com.dfdt.delivery.domain.ai.application.usecase;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.ai.application.dto.RollbackDescriptionCommand;
+import com.dfdt.delivery.domain.ai.application.dto.RollbackDescriptionResult;
+import com.dfdt.delivery.domain.ai.domain.entity.AiLogEntity;
+import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
+import com.dfdt.delivery.domain.ai.domain.repository.AiLogRepository;
+import com.dfdt.delivery.domain.product.domain.entity.Product;
+import com.dfdt.delivery.domain.product.domain.repository.ProductRepository;
+import com.dfdt.delivery.domain.store.domain.entity.Store;
+import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.enums.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.lenient;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RollbackDescriptionUseCaseImpl 테스트")
+class RollbackDescriptionUseCaseImplTest {
+
+    @Mock
+    private AiLogRepository aiLogRepository;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @InjectMocks
+    private RollbackDescriptionUseCaseImpl sut;
+
+    private UUID storeId;
+    private UUID aiLogId;
+    private UUID productId;
+    private String requestedBy;
+
+    @BeforeEach
+    void setUp() {
+        storeId = UUID.randomUUID();
+        aiLogId = UUID.randomUUID();
+        productId = UUID.randomUUID();
+        requestedBy = "owner123";
+    }
+
+    // ──────────────────────────────────────────────────
+    // 정상 케이스
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("정상 원복")
+    class SuccessTests {
+
+        @Test
+        @DisplayName("apply된 로그를 OWNER가 원복하면 이전 설명으로 복원된다")
+        void shouldRollbackSuccessfullyForOwner() {
+            // given
+            AiLogEntity mockLog = mockAppliedLog(storeId, productId, "이전 설명", null);
+            Product mockProduct = mock(Product.class);
+            Store mockStore = mockStore(requestedBy);
+
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+            given(productRepository.findByProductIdAndStoreId(productId, storeId)).willReturn(Optional.of(mockProduct));
+
+            RollbackDescriptionCommand command = new RollbackDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER
+            );
+
+            // when & then
+            assertThatCode(() -> sut.execute(command)).doesNotThrowAnyException();
+            then(mockProduct).should().restoreDescription(eq("이전 설명"), eq(requestedBy));
+        }
+
+        @Test
+        @DisplayName("MASTER는 소유권 체크 없이 원복할 수 있다")
+        void masterCanRollbackWithoutOwnershipCheck() {
+            // given
+            AiLogEntity mockLog = mockAppliedLog(storeId, productId, "이전 설명", null);
+            Product mockProduct = mock(Product.class);
+
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+            given(productRepository.findByProductIdAndStoreId(productId, storeId)).willReturn(Optional.of(mockProduct));
+
+            RollbackDescriptionCommand command = new RollbackDescriptionCommand(
+                    storeId, aiLogId, "masterUser", UserRole.MASTER
+            );
+
+            // when & then
+            assertThatCode(() -> sut.execute(command)).doesNotThrowAnyException();
+            then(storeRepository).shouldHaveNoInteractions();
+        }
+
+        @Test
+        @DisplayName("previousDescription이 null이어도 원복이 가능하다 (설명 없는 상태로 복원)")
+        void shouldRollbackEvenWhenPreviousDescriptionIsNull() {
+            // given
+            AiLogEntity mockLog = mockAppliedLog(storeId, productId, null, null);
+            Product mockProduct = mock(Product.class);
+
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+            given(productRepository.findByProductIdAndStoreId(productId, storeId)).willReturn(Optional.of(mockProduct));
+
+            RollbackDescriptionCommand command = new RollbackDescriptionCommand(
+                    storeId, aiLogId, "masterUser", UserRole.MASTER
+            );
+
+            // when & then
+            assertThatCode(() -> sut.execute(command)).doesNotThrowAnyException();
+            then(mockProduct).should().restoreDescription(isNull(), eq("masterUser"));
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // AiLog 관련 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AiLog 관련 예외")
+    class AiLogExceptionTests {
+
+        @Test
+        @DisplayName("존재하지 않는 aiLogId → AI_LOG_NOT_FOUND")
+        void shouldThrowWhenAiLogNotFound() {
+            // given
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.empty());
+
+            RollbackDescriptionCommand command = new RollbackDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER
+            );
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.AI_LOG_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("storeId 불일치 → STORE_NOT_FOUND")
+        void shouldThrowWhenStoreIdMismatch() {
+            // given
+            UUID differentStoreId = UUID.randomUUID();
+            AiLogEntity mockLog = mockAppliedLog(differentStoreId, productId, "이전 설명", null);
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+
+            RollbackDescriptionCommand command = new RollbackDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER
+            );
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("아직 적용되지 않은 로그 → NOT_YET_APPLIED")
+        void shouldThrowWhenNotYetApplied() {
+            // given — isApplied = false
+            AiLogEntity mockLog = mockNotAppliedLog(storeId, productId);
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+
+            RollbackDescriptionCommand command = new RollbackDescriptionCommand(
+                    storeId, aiLogId, "masterUser", UserRole.MASTER
+            );
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.NOT_YET_APPLIED));
+        }
+
+        @Test
+        @DisplayName("이미 롤백된 로그 → ALREADY_ROLLED_BACK")
+        void shouldThrowWhenAlreadyRolledBack() {
+            // given — rolledBackAt != null
+            AiLogEntity mockLog = mockAppliedLog(storeId, productId, "이전 설명", OffsetDateTime.now().minusMinutes(5));
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+
+            RollbackDescriptionCommand command = new RollbackDescriptionCommand(
+                    storeId, aiLogId, "masterUser", UserRole.MASTER
+            );
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.ALREADY_ROLLED_BACK));
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // Store 소유권 예외
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("Store 소유권 예외")
+    class StoreOwnershipTests {
+
+        @Test
+        @DisplayName("OWNER가 타인 가게 로그 원복 시도 → STORE_ACCESS_DENIED")
+        void shouldThrowWhenOwnerAccessesDifferentStore() {
+            // given
+            AiLogEntity mockLog = mockAppliedLog(storeId, productId, "이전 설명", null);
+            Store mockStore = mockStore("anotherOwner");
+
+            given(aiLogRepository.findById(aiLogId)).willReturn(Optional.of(mockLog));
+            given(storeRepository.findByStoreIdAndNotDeleted(storeId)).willReturn(Optional.of(mockStore));
+
+            RollbackDescriptionCommand command = new RollbackDescriptionCommand(
+                    storeId, aiLogId, requestedBy, UserRole.OWNER
+            );
+
+            // when & then
+            assertThatThrownBy(() -> sut.execute(command))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(AiErrorCode.STORE_ACCESS_DENIED));
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // 헬퍼 메서드
+    // ──────────────────────────────────────────────────
+
+    private AiLogEntity mockAppliedLog(UUID logStoreId, UUID logProductId,
+                                       String previousDescription, OffsetDateTime rolledBackAt) {
+        AiLogEntity log = mock(AiLogEntity.class);
+        lenient().when(log.getStoreId()).thenReturn(logStoreId);
+        lenient().when(log.getProductId()).thenReturn(logProductId);
+        lenient().when(log.getIsApplied()).thenReturn(true);
+        lenient().when(log.getRolledBackAt()).thenReturn(rolledBackAt);
+        lenient().when(log.getPreviousDescription()).thenReturn(previousDescription);
+        lenient().when(log.getAiLogId()).thenReturn(aiLogId);
+        lenient().when(log.getRolledBackAt()).thenReturn(rolledBackAt);
+        return log;
+    }
+
+    private AiLogEntity mockNotAppliedLog(UUID logStoreId, UUID logProductId) {
+        AiLogEntity log = mock(AiLogEntity.class);
+        lenient().when(log.getStoreId()).thenReturn(logStoreId);
+        lenient().when(log.getProductId()).thenReturn(logProductId);
+        lenient().when(log.getIsApplied()).thenReturn(false);
+        return log;
+    }
+
+    private Store mockStore(String ownerUsername) {
+        User mockUser = mock(User.class);
+        lenient().when(mockUser.getUsername()).thenReturn(ownerUsername);
+        Store mockStore = mock(Store.class);
+        lenient().when(mockStore.getUser()).thenReturn(mockUser);
+        return mockStore;
+    }
+}

--- a/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/ai/presentation/controller/AiDescriptionControllerTest.java
@@ -4,18 +4,22 @@ import com.dfdt.delivery.common.config.SecurityConfig;
 import com.dfdt.delivery.domain.ai.application.dto.AiHealthResult;
 import com.dfdt.delivery.domain.ai.application.dto.AiLogDetailResult;
 import com.dfdt.delivery.domain.ai.application.dto.AiLogSummaryResult;
+import com.dfdt.delivery.domain.ai.application.dto.AiStatsResult;
 import com.dfdt.delivery.domain.ai.application.dto.ApplyDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.dto.AiPromptRulesResult;
 import com.dfdt.delivery.domain.ai.application.dto.GenerateImageResult;
 import com.dfdt.delivery.domain.ai.application.dto.RetryDescriptionResult;
+import com.dfdt.delivery.domain.ai.application.dto.RollbackDescriptionResult;
 import com.dfdt.delivery.domain.ai.application.usecase.ApplyDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.CheckAiHealthUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GenerateImageUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetAiLogDetailUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.GetAiStatsUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.GetPromptRulesUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.RetryDescriptionUseCase;
+import com.dfdt.delivery.domain.ai.application.usecase.RollbackDescriptionUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.application.usecase.SearchProductAiLogsUseCase;
 import com.dfdt.delivery.domain.ai.domain.entity.enums.AiRequestType;
@@ -94,7 +98,13 @@ class AiDescriptionControllerTest {
     private RetryDescriptionUseCase retryDescriptionUseCase;
 
     @MockBean
+    private RollbackDescriptionUseCase rollbackDescriptionUseCase;
+
+    @MockBean
     private GenerateImageUseCase generateImageUseCase;
+
+    @MockBean
+    private GetAiStatsUseCase getAiStatsUseCase;
 
     @MockBean
     private com.dfdt.delivery.domain.auth.infrastructure.jwt.JwtProvider jwtProvider;
@@ -1031,6 +1041,137 @@ class AiDescriptionControllerTest {
             mockMvc.perform(post("/api/v1/ai/stores/{storeId}/images/preview", storeId)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestBody)))
+                    .andExpect(status().is4xxClientError());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // API-AI-205: AI 설명 원복
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AI 설명 원복 (API-AI-205)")
+    class RollbackDescriptionTests {
+
+        private UUID aiLogId;
+        private UUID productId;
+
+        @BeforeEach
+        void setUpRollback() {
+            aiLogId = UUID.randomUUID();
+            productId = UUID.randomUUID();
+        }
+
+        @Test
+        @DisplayName("OWNER가 요청하면 200과 원복 결과를 반환한다")
+        void ownerShouldReturn200WithRollbackResult() throws Exception {
+            // given
+            RollbackDescriptionResult mockResult = new RollbackDescriptionResult(
+                    aiLogId, productId, "원래 설명이었던 치킨", OffsetDateTime.now()
+            );
+            given(rollbackDescriptionUseCase.execute(any())).willReturn(mockResult);
+
+            // when & then
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/rollback",
+                            storeId, aiLogId)
+                            .with(user(ownerDetails)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.aiLogId").value(aiLogId.toString()))
+                    .andExpect(jsonPath("$.data.productId").value(productId.toString()))
+                    .andExpect(jsonPath("$.data.restoredDescription").value("원래 설명이었던 치킨"));
+        }
+
+        @Test
+        @DisplayName("MASTER도 200을 반환한다")
+        void masterShouldReturn200() throws Exception {
+            // given
+            given(rollbackDescriptionUseCase.execute(any())).willReturn(
+                    new RollbackDescriptionResult(aiLogId, productId, "이전 설명", OffsetDateTime.now())
+            );
+
+            // when & then
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/rollback",
+                            storeId, aiLogId)
+                            .with(user(masterDetails)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 요청은 4xx를 반환한다")
+        void unauthenticatedShouldReturn4xx() throws Exception {
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/rollback",
+                            storeId, aiLogId))
+                    .andExpect(status().is4xxClientError());
+        }
+
+        @Test
+        @DisplayName("CUSTOMER 역할은 403을 반환한다")
+        void customerShouldReturn403() throws Exception {
+            User customer = User.builder()
+                    .username("customer1").name("고객").password("pw").role(UserRole.CUSTOMER).build();
+            CustomUserDetails customerDetails = new CustomUserDetails(customer);
+
+            mockMvc.perform(post("/api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/rollback",
+                            storeId, aiLogId)
+                            .with(user(customerDetails)))
+                    .andExpect(status().isForbidden());
+        }
+    }
+
+    // ──────────────────────────────────────────────────
+    // API-AI-204: AI 호출 통계
+    // ──────────────────────────────────────────────────
+    @Nested
+    @DisplayName("AI 호출 통계 (API-AI-204)")
+    class GetAiStatsTests {
+
+        @Test
+        @DisplayName("MASTER가 요청하면 200과 통계를 반환한다")
+        void masterShouldReturn200WithStats() throws Exception {
+            // given
+            AiStatsResult mockResult = new AiStatsResult(storeId, 20L, 18L, 2L, 90.0, 320L, null, null);
+            given(getAiStatsUseCase.execute(any())).willReturn(mockResult);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/stats", storeId)
+                            .with(user(masterDetails)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status").value(200))
+                    .andExpect(jsonPath("$.data.storeId").value(storeId.toString()))
+                    .andExpect(jsonPath("$.data.totalCount").value(20))
+                    .andExpect(jsonPath("$.data.successCount").value(18))
+                    .andExpect(jsonPath("$.data.failureCount").value(2))
+                    .andExpect(jsonPath("$.data.successRate").value(90.0))
+                    .andExpect(jsonPath("$.data.avgResponseTimeMs").value(320));
+        }
+
+        @Test
+        @DisplayName("조회 결과가 없으면 totalCount=0으로 반환한다")
+        void shouldReturn200WithZeroStats() throws Exception {
+            // given
+            AiStatsResult mockResult = new AiStatsResult(storeId, 0L, 0L, 0L, 0.0, null, null, null);
+            given(getAiStatsUseCase.execute(any())).willReturn(mockResult);
+
+            // when & then
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/stats", storeId)
+                            .with(user(masterDetails)))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.totalCount").value(0))
+                    .andExpect(jsonPath("$.data.avgResponseTimeMs").doesNotExist());
+        }
+
+        @Test
+        @DisplayName("OWNER 역할은 403을 반환한다")
+        void ownerShouldReturn403() throws Exception {
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/stats", storeId)
+                            .with(user(ownerDetails)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
+        @DisplayName("인증되지 않은 요청은 4xx를 반환한다")
+        void unauthenticatedShouldReturn4xx() throws Exception {
+            mockMvc.perform(get("/api/v1/ai/stores/{storeId}/stats", storeId))
                     .andExpect(status().is4xxClientError());
         }
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

## 📌 작업 내용
  ---                                                  
  작업 내용                                            
                                                       
  API-AI-204 — 가게별 AI 호출 통계 조회 (MASTER 전용)  

  GET /api/v1/ai/stores/{storeId}/stats                
                                                       
  MASTER 권한으로 특정 가게의 AI 호출 현황을 집계하는 읽기 전용 API입니다. 
  날짜 범위와 요청 타입(PRODUCT_DESCRIPTION / FOOD_IMAGE_GENERATION)으로 필터링할 수 있으며, 생략 시 전체 기간·전체 타입을 대상으로 합니다.

  지원 파라미터:
  - fromDateTime / toDateTime (선택, ISO-8601) — 최대 90일 범위 제한
  - requestType (선택) — PRODUCT_DESCRIPTION | FOOD_IMAGE_GENERATION

  응답 필드: totalCount, successCount, failureCount, successRate(%), avgResponseTimeMs

  ---
  API-AI-205 — AI 적용 상품 설명 원복 (rollback)

  POST /api/v1/ai/stores/{storeId}/descriptions/{aiLogId}/rollback

  apply 완료된 AI 로그를 대상으로, apply 시점에 저장해 둔 previousDescription 스냅샷으로 상품 설명을 복원합니다.
  OWNER는 본인 가게에만, MASTER는 모든 가게에 적용할 수 있습니다.

  선행 조건:
  1. preview 생성으로 aiLogId 획득
  2. apply로 isApplied = true 전환 + previousDescription 스냅샷 저장
  3. 이후 rollback 호출 가능

  ---
  부가 수정 — modelName / responseTimeMs null 버그 수정

  기존 모든 AI UseCase(GenerateDescription, RetryDescription, GenerateImage)에서 modelName과 responseTimeMs가 null로 저장되던 문제를 함께 수정했습니다.


## ✅ 주요 변경 사항

Layer | 파일 | 역할
-- | -- | --
Application | AiStatsQuery | 통계 조회 입력 커맨드
Application | AiStatsResult | 통계 집계 결과
Application | GetAiStatsUseCase | 통계 조회 UseCase
Application | GetAiStatsUseCaseImpl | 날짜 검증 + QueryDSL 조회
Presentation | AiStatsResponse | 통계 API 응답 DTO
Application | RollbackDescriptionCommand | 설명 원복 입력
Application | RollbackDescriptionResult | 원복 결과 DTO
Application | RollbackDescriptionUseCase / Impl | 설명 원복 로직
Presentation | RollbackDescriptionResponse | 원복 API 응답 DTO

  기존 파일 수정

  AiLogCustomRepository / AiLogCustomRepositoryImpl
  - getAiStats() 메서드 추가
  - QueryDSL 3-query 방식으로 totalCount, successCount, avgResponseTimeMs 를 각각 집계
  - BooleanExpression[] 배열에서 null 조건을 스트림으로 필터링 후 .where() 에 전달

  AiErrorCode — 에러 코드 2개 추가
  NOT_YET_APPLIED(409, "AI-4095", "적용되지 않은 AI 로그는 원복할 수 없습니다.")
  ALREADY_ROLLED_BACK(409, "AI-4096", "이미 원복된 AI 로그입니다.")

  Product — 도메인 메서드 1개 추가
  public void restoreDescription(String previousDescription, String username) {
      this.description = previousDescription;
      this.isAiDescription = false;
      makeUpdateAudit(username);
  }

  GeminiClient / ImageGenerationClient — getModelName() 인터페이스 추가
  - UseCase 계층이 infrastructure(GeminiProperties)를 직접 참조하지 않도록 도메인 클라이언트 인터페이스에 getModelName() 선언
  - GeminiWebClient → properties.model() 반환
  - GeminiImageWebClient → properties.imageModel() 반환

  GenerateDescriptionUseCaseImpl / RetryDescriptionUseCaseImpl / GenerateImageUseCaseImpl
  - API 호출 직전 System.currentTimeMillis() 로 타이머 시작
  - 성공/실패 모든 경로에서 responseTimeMs 계산 후 로그 저장
  - modelName 을 geminiClient.getModelName() 으로 채워서 저장

  AiDescriptionController — 엔드포인트 2개 추가
  - POST /stores/{storeId}/descriptions/{aiLogId}/rollback (OWNER / MASTER)
  - GET /stores/{storeId}/stats (MASTER, @DateTimeFormat(iso = DATE_TIME))

  ---



## 🧪 테스트 / 확인 방법
- [ ] 로컬 실행 확인
- [ ] 주요 시나리오 동작 확인
- [ ] 예외 케이스 확인 (해당 시)

### 확인 방법 (선택)
  ---
  테스트 결과

  신규 단위 테스트


GetAiStatsUseCaseImplTest — 6개 테스트
테스트 | 검증 내용
-- | --
날짜 조건 없이 전체 기간 통계 반환 | totalCount, successRate, avgResponseTimeMs 정합성
날짜 범위 지정 시 정상 반환 | fromDateTime 필터 반영 여부
AI 호출이 없을 때 | totalCount = 0, successRate = 0.0 처리
fromDateTime > toDateTime | INVALID_DATE_RANGE 예외
90일 초과 범위 | DATE_RANGE_EXCEEDED 예외
정확히 90일 범위 | 경계값 정상 통과

RollbackDescriptionUseCaseImplTest — 6개 테스트

테스트 | 검증 내용
-- | --
OWNER가 apply된 로그 원복 성공 | product.restoreDescription() 호출 확인
MASTER는 소유권 체크 없이 원복 | storeRepository 미호출 검증
previousDescription이 null이어도 원복 가능 | null 설명으로 복원
존재하지 않는 aiLogId | AI_LOG_NOT_FOUND 예외
storeId 불일치 | STORE_NOT_FOUND (URL 위변조 방어)
아직 적용되지 않은 로그 | NOT_YET_APPLIED 예외
이미 롤백된 로그 | ALREADY_ROLLED_BACK 예외
OWNER가 타인 가게 접근 | STORE_ACCESS_DENIED 예외


AiDescriptionControllerTest

테스트 그룹 | 설명
-- | --
RollbackDescriptionTests | 설명 원복 API 테스트
GetAiStatsTests | AI 통계 조회 API 테스트

빌드 / 전체 테스트
./gradlew test --tests "com.dfdt.delivery.domain.ai.*"

결과

BUILD SUCCESSFUL


## ⚠️ 영향 범위 (해당 시 체크)
- [ ] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정

## 👀 리뷰 포인트 (선택)
  1. QueryDSL 통계 집계 방식 (3-query vs 1-query Tuple)

  복잡한 CaseBuilder Tuple 쿼리 대신 totalCount, successCount, avgResponseTimeMs를 각각 별도 쿼리로 조회했습니다. 가독성과 유지보수성이 높아지지만 DB 쿼리가 3번 발생합니다. 통계 API
  호출 빈도가 낮은 MASTER 전용이므로 3-query 방식이 적합하다고 판단했으나, 성능 요구사항이 강해지면 Tuple 방식으로 전환 가능합니다.

  2. successRate 반올림 정밀도

  Math.round(success * 1000.0 / total) / 10.0 방식으로 소수점 1자리까지 계산합니다. (예: 38/42 → 90.5%) 소수점 자릿수 스펙이 변경되면 해당 공식을 조정해야 합니다.

  3. restoreDescription()의 isAiDescription = false 처리

  원복 후 상품 설명이 AI 생성 설명이 아님을 명시적으로 표시합니다. previousDescription이 null이면 (AI 적용 이전에 설명이 없었던 경우) 설명이 null로 복원됩니다. 이 동작이 비즈니스
  요구사항에 부합하는지 확인이 필요합니다.

  4. responseTimeMs의 int 캐스팅

  (int)(System.currentTimeMillis() - startMs) 로 캐스팅합니다. 이론상 약 24.8일을 초과하면 오버플로가 발생하지만, AI API 타임아웃은 수 초 내외이므로 실용적으로 문제없습니다.

  5. modelName / responseTimeMs 수정이 기존 로그에 미치는 영향

  이번 수정 이전에 저장된 AI 로그들은 modelName과 responseTimeMs가 null로 남아 있습니다. 통계 쿼리의 avgResponseTimeMs는 null을 제외하고 집계하므로 기존 데이터가 섞여도 통계에 왜곡이
   없습니다. 다만 히스토리 데이터가 필요하다면 별도 마이그레이션이 필요합니다.

