### PR TITLE
Feat : Address 도메인 아키텍처 구축 및 서비스 테스트 코드 작성, Docs : AddressController …

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/address/application/service/AddressService.java
+++ b/src/main/java/com/dfdt/delivery/domain/address/application/service/AddressService.java
@@ -1,0 +1,177 @@
+package com.dfdt.delivery.domain.address.application.service;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.address.domain.entity.Address;
+import com.dfdt.delivery.domain.address.domain.exception.error.enums.AddressErrorCode;
+import com.dfdt.delivery.domain.address.domain.repository.AddressRepository;
+import com.dfdt.delivery.domain.address.presentation.dto.AddressRequest;
+import com.dfdt.delivery.domain.address.presentation.dto.AddressResponse;
+import com.dfdt.delivery.domain.region.domain.entity.Region;
+import com.dfdt.delivery.domain.region.domain.enums.RegionErrorCode;
+import com.dfdt.delivery.domain.region.domain.repository.RegionRepository;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.exception.error.enums.UserErrorCode;
+import com.dfdt.delivery.domain.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * 배송지 관련 비즈니스 로직을 처리하는 서비스.
+ * 기본 배송지 자동 변경, 소유자 검증, Soft Delete 등을 포함.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AddressService {
+
+    private final AddressRepository addressRepository;
+    private final UserRepository userRepository;
+    private final RegionRepository regionRepository;
+
+    /**
+     * 새로운 배송지를 등록.
+     * 등록 시 'isDefault'가 true인 경우, 기존 기본 배송지를 일반 배송지로 변경.
+     * @param username 사용자 계정
+     * @param request 배송지 등록 요청 정보
+     * @return 등록된 배송지 정보 응답 DTO
+     */
+    @Transactional
+    public AddressResponse createAddress(String username, AddressRequest.Create request) {
+        User user = findUserOrThrow(username);
+        Region region = findRegionOrThrow(request.getRegionId());
+
+        // 기본 배송지로 설정하는 경우 기존 기본 배송지 해제
+        if (Boolean.TRUE.equals(request.getIsDefault())) {
+            resetDefaultAddress(user);
+        }
+
+        Address address = Address.builder()
+                .user(user)
+                .region(region)
+                .addressName(request.getAddressName())
+                .addressLine1(request.getAddressLine1())
+                .addressLine2(request.getAddressLine2())
+                .receiverName(request.getReceiverName())
+                .receiverPhone(request.getReceiverPhone())
+                .isDefault(request.getIsDefault())
+                .deliveryMemo(request.getDeliveryMemo())
+                .build();
+
+        Address savedAddress = addressRepository.save(address);
+        return AddressResponse.from(savedAddress);
+    }
+
+    /**
+     * 사용자의 유효한(삭제되지 않은) 배송지 목록을 조회.
+     * @param username 사용자 계정
+     * @return 배송지 목록 응답 DTO 리스트
+     */
+    public List<AddressResponse> getMyAddresses(String username) {
+        User user = findUserOrThrow(username);
+        return addressRepository.findByUserAndSoftDeleteAuditDeletedAtIsNull(user)
+                .stream()
+                .map(AddressResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 상세 정보를 조회합니다. 소유자 여부를 검증.
+     * @param username 사용자 계정 (소유권 확인용)
+     * @param addressId 배송지 ID
+     * @return 배송지 상세 정보 응답 DTO
+     */
+    public AddressResponse getAddress(String username, UUID addressId) {
+        Address address = findAddressAndValidateOwner(username, addressId);
+        return AddressResponse.from(address);
+    }
+
+    /**
+     * 배송지 정보를 업데이트합니다.
+     * 기본 배송지 여부가 변경될 경우 기존 기본 배송지를 해제.
+     * @param username 사용자 계정
+     * @param addressId 수정할 배송지 ID
+     * @param request 수정할 배송지 정보
+     * @return 수정된 배송지 정보 응답 DTO
+     */
+    @Transactional
+    public AddressResponse updateAddress(String username, UUID addressId, AddressRequest.Update request) {
+        Address address = findAddressAndValidateOwner(username, addressId);
+
+        // 지역 변경이 요청된 경우에만 조회 및 업데이트
+        Region region = (request.getRegionId() != null) ? findRegionOrThrow(request.getRegionId()) : null;
+
+        // 기본 배송지 상태 변경 시 중복 방지 로직 실행
+        if (Boolean.TRUE.equals(request.getIsDefault())) {
+            resetDefaultAddress(address.getUser());
+        }
+
+        address.updateAddressInfo(
+                region,
+                request.getAddressName(),
+                request.getAddressLine1(),
+                request.getAddressLine2(),
+                request.getReceiverName(),
+                request.getReceiverPhone(),
+                request.getDeliveryMemo()
+        );
+
+        if (request.getIsDefault() != null) {
+            address.changeDefaultStatus(request.getIsDefault());
+        }
+
+        return AddressResponse.from(address);
+    }
+
+    /**
+     * 배송지를 논리적으로 삭제(Soft Delete).
+     * @param username 사용자 계정 (소유권 확인용)
+     * @param addressId 삭제할 배송지 ID
+     */
+    @Transactional
+    public void deleteAddress(String username, UUID addressId) {
+        Address address = findAddressAndValidateOwner(username, addressId);
+        address.deleteAddress(username);
+    }
+
+    /**
+     * 사용자의 기존 기본 배송지를 찾아 비활성화(false) 처리.
+     */
+    private void resetDefaultAddress(User user) {
+        addressRepository.findByUserAndIsDefaultTrueAndSoftDeleteAuditDeletedAtIsNull(user)
+                .ifPresent(address -> address.changeDefaultStatus(false));
+    }
+
+    /**
+     * 사용자 식별자로 사용자 엔티티를 조회.
+     */
+    private User findUserOrThrow(String username) {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new BusinessException(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    /**
+     * 지역 식별자로 지역 엔티티를 조회.
+     */
+    private Region findRegionOrThrow(UUID regionId) {
+        return regionRepository.findById(regionId)
+                .orElseThrow(() -> new BusinessException(RegionErrorCode.NOT_FOUND_REGION));
+    }
+
+    /**
+     * 배송지 식별자로 조회하고, 요청한 사용자가 소유자인지 검증.
+     */
+    private Address findAddressAndValidateOwner(String username, UUID addressId) {
+        Address address = addressRepository.findByAddressIdAndSoftDeleteAuditDeletedAtIsNull(addressId)
+                .orElseThrow(() -> new BusinessException(AddressErrorCode.ADDRESS_NOT_FOUND));
+
+        if (!address.getUser().getUsername().equals(username)) {
+            throw new BusinessException(AddressErrorCode.ADDRESS_ACCESS_DENIED);
+        }
+        return address;
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/address/domain/entity/Address.java
+++ b/src/main/java/com/dfdt/delivery/domain/address/domain/entity/Address.java
@@ -3,46 +3,68 @@ package com.dfdt.delivery.domain.address.domain.entity;
 import com.dfdt.delivery.common.infrastructure.persistence.embedded.CreateAudit;
 import com.dfdt.delivery.common.infrastructure.persistence.embedded.SoftDeleteAudit;
 import com.dfdt.delivery.common.infrastructure.persistence.embedded.UpdateAudit;
+import com.dfdt.delivery.domain.region.domain.entity.Region;
+import com.dfdt.delivery.domain.user.domain.entity.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.util.UUID;
 
+/**
+ * 배송지 엔티티.
+ * 사용자가 등록한 배송 주소 정보를 관리하며, 기본 배송지 여부와 지역 정보를 포함합니다.
+ */
 @Entity
+@Table(
+        name = "p_address",
+        indexes = {
+                @Index(name = "IDX_address_username", columnList = "username"),
+                @Index(name = "IDX_address_username_default", columnList = "username, is_default"),
+                @Index(name = "IDX_address_region_id", columnList = "region_id")
+        }
+)
 @Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Table(name = "p_address")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 public class Address {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "address_id")
+    @Column(name = "address_id", updatable = false, nullable = false)
     private UUID addressId;
 
-    @Column(length = 50)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "username", referencedColumnName = "username", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "region_id", nullable = false)
+    private Region region;
+
+    @Column(name = "address_name", length = 50)
     private String addressName;
 
     @NotBlank
-    @Column(length = 255, nullable = false)
+    @Column(name = "address_line1", length = 255, nullable = false)
     private String addressLine1;
 
-    @Column(length = 255)
+    @Column(name = "address_line2", length = 255)
     private String addressLine2;
 
-    @Column(length = 50)
+    @Column(name = "receiver_name", length = 50)
     private String receiverName;
 
-    @Column(length = 20)
+    @Column(name = "receiver_phone", length = 20)
     @Pattern(regexp = "^(0\\d{1,2})-?\\d{3,4}-?\\d{4}$")
     private String receiverPhone;
 
-    @Column(nullable = false)
-    private Boolean isDefault = true;
+    @Column(name = "is_default", nullable = false)
+    private Boolean isDefault = false;
 
-    @Column(length = 255)
+    @Column(name = "delivery_memo", length = 255)
     private String deliveryMemo;
 
     @Embedded
@@ -53,4 +75,56 @@ public class Address {
 
     @Embedded
     private SoftDeleteAudit softDeleteAudit;
+
+    @Builder
+    public Address(User user, Region region, String addressName, String addressLine1,
+                   String addressLine2, String receiverName, String receiverPhone,
+                   Boolean isDefault, String deliveryMemo) {
+        this.user = user;
+        this.region = region;
+        this.addressName = addressName;
+        this.addressLine1 = addressLine1;
+        this.addressLine2 = addressLine2;
+        this.receiverName = receiverName;
+        this.receiverPhone = receiverPhone;
+        this.isDefault = (isDefault != null) ? isDefault : false;
+        this.deliveryMemo = deliveryMemo;
+
+        this.createAudit = CreateAudit.now(user != null ? user.getUsername() : "system");
+        this.updateAudit = UpdateAudit.empty();
+        this.softDeleteAudit = SoftDeleteAudit.active();
+    }
+
+    /**
+     * 기본 배송지 상태 변경 로직
+     * 서비스 레이어에서 다른 주소들을 false로 만들 때 이 메서드를 사용.
+     */
+    public void changeDefaultStatus(boolean isDefault) {
+        this.isDefault = isDefault;
+    }
+
+    /**
+     * 주소 정보 업데이트 로직
+     */
+    public void updateAddressInfo(Region region, String addressName, String addressLine1,
+                                  String addressLine2, String receiverName,
+                                  String receiverPhone, String deliveryMemo) {
+        if (region != null) this.region = region;
+        if (addressName != null) this.addressName = addressName;
+        if (addressLine1 != null && !addressLine1.isBlank()) this.addressLine1 = addressLine1;
+        if (addressLine2 != null) this.addressLine2 = addressLine2;
+        if (receiverName != null) this.receiverName = receiverName;
+        if (receiverPhone != null) this.receiverPhone = receiverPhone;
+        if (deliveryMemo != null) this.deliveryMemo = deliveryMemo;
+    }
+
+    /**
+     * Soft Delete 로직
+     */
+    public void deleteAddress(String deleteBy) {
+        if (this.softDeleteAudit == null) {
+            this.softDeleteAudit = SoftDeleteAudit.active();
+        }
+        this.softDeleteAudit.softDelete(deleteBy);
+    }
 }

--- a/src/main/java/com/dfdt/delivery/domain/address/domain/exception/error/enums/AddressErrorCode.java
+++ b/src/main/java/com/dfdt/delivery/domain/address/domain/exception/error/enums/AddressErrorCode.java
@@ -1,0 +1,16 @@
+package com.dfdt.delivery.domain.address.domain.exception.error.enums;
+
+import com.dfdt.delivery.common.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AddressErrorCode implements ErrorCode {
+    ADDRESS_NOT_FOUND(404, "ADDRESS-001", "배송지를 찾을 수 없습니다."),
+    ADDRESS_ACCESS_DENIED(403, "ADDRESS-002", "배송지에 대한 권한이 없습니다.");
+
+    private final int status;
+    private final String errorCode;
+    private final String message;
+}

--- a/src/main/java/com/dfdt/delivery/domain/address/domain/repository/AddressRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/address/domain/repository/AddressRepository.java
@@ -1,9 +1,16 @@
 package com.dfdt.delivery.domain.address.domain.repository;
 
 import com.dfdt.delivery.domain.address.domain.entity.Address;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.dfdt.delivery.domain.user.domain.entity.User;
 
+import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
-public interface AddressRepository extends JpaRepository<Address, UUID> {
+public interface AddressRepository {
+    Address save(Address address);
+    Optional<Address> findById(UUID id);
+    List<Address> findByUserAndSoftDeleteAuditDeletedAtIsNull(User user);
+    Optional<Address> findByUserAndIsDefaultTrueAndSoftDeleteAuditDeletedAtIsNull(User user);
+    Optional<Address> findByAddressIdAndSoftDeleteAuditDeletedAtIsNull(UUID addressId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/address/infrastructure/persistence/repository/JpaAddressRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/address/infrastructure/persistence/repository/JpaAddressRepository.java
@@ -1,0 +1,10 @@
+package com.dfdt.delivery.domain.address.infrastructure.persistence.repository;
+
+import com.dfdt.delivery.domain.address.domain.entity.Address;
+import com.dfdt.delivery.domain.address.domain.repository.AddressRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface JpaAddressRepository extends JpaRepository<Address, UUID>, AddressRepository {
+}

--- a/src/main/java/com/dfdt/delivery/domain/address/presentation/controller/AddressController.java
+++ b/src/main/java/com/dfdt/delivery/domain/address/presentation/controller/AddressController.java
@@ -1,0 +1,97 @@
+package com.dfdt.delivery.domain.address.presentation.controller;
+
+import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.address.application.service.AddressService;
+import com.dfdt.delivery.domain.address.presentation.dto.AddressRequest;
+import com.dfdt.delivery.domain.address.presentation.dto.AddressResponse;
+import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 배송지 관련 API를 제공하는 컨트롤러.
+ * 사용자의 배송지 등록, 조회, 수정, 삭제 기능을 담당.
+ */
+@RestController
+@RequestMapping("/api/v1/addresses")
+@RequiredArgsConstructor
+public class AddressController implements AddressControllerDocs {
+
+    private final AddressService addressService;
+
+    /**
+     * 새로운 배송지를 등록.
+     * @param userDetails 인증된 사용자 정보
+     * @param request 배송지 등록 요청 정보 (지역 ID, 상세 주소 등)
+     * @return 등록된 배송지 정보
+     */
+    @PostMapping
+    public ResponseEntity<ApiResponseDto<AddressResponse>> createAddress(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody AddressRequest.Create request) {
+        AddressResponse response = addressService.createAddress(userDetails.getUsername(), request);
+        return ApiResponseDto.success(201, "배송지가 등록되었습니다.", response);
+    }
+
+    /**
+     * 로그인한 사용자의 모든 배송지 목록을 조회. (삭제되지 않은 주소만 조회)
+     * @param userDetails 인증된 사용자 정보
+     * @return 배송지 목록 응답 DTO 리스트
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponseDto<List<AddressResponse>>> getMyAddresses(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<AddressResponse> response = addressService.getMyAddresses(userDetails.getUsername());
+        return ApiResponseDto.success(200, "배송지 목록 조회가 성공하였습니다.", response);
+    }
+
+    /**
+     * 특정 배송지 상세 정보를 조회.
+     * @param userDetails 인증된 사용자 정보 (소유권 확인용)
+     * @param addressId 조회할 배송지 ID (UUID)
+     * @return 배송지 상세 정보 응답 DTO
+     */
+    @GetMapping("/{addressId}")
+    public ResponseEntity<ApiResponseDto<AddressResponse>> getAddress(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable UUID addressId) {
+        AddressResponse response = addressService.getAddress(userDetails.getUsername(), addressId);
+        return ApiResponseDto.success(200, "배송지 조회가 성공하였습니다.", response);
+    }
+
+    /**
+     * 기존 배송지 정보를 수정.
+     * @param userDetails 인증된 사용자 정보 (소유권 확인용)
+     * @param addressId 수정할 배송지 ID (UUID)
+     * @param request 수정할 배송지 정보
+     * @return 수정된 배송지 정보 응답 DTO
+     */
+    @PutMapping("/{addressId}")
+    public ResponseEntity<ApiResponseDto<AddressResponse>> updateAddress(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable UUID addressId,
+            @Valid @RequestBody AddressRequest.Update request) {
+        AddressResponse response = addressService.updateAddress(userDetails.getUsername(), addressId, request);
+        return ApiResponseDto.success(200, "배송지가 수정되었습니다.", response);
+    }
+
+    /**
+     * 배송지를 삭제합니다. (Soft Delete)
+     * @param userDetails 인증된 사용자 정보 (소유권 확인용)
+     * @param addressId 삭제할 배송지 ID (UUID)
+     * @return 삭제 완료 메시지
+     */
+    @DeleteMapping("/{addressId}")
+    public ResponseEntity<ApiResponseDto<Void>> deleteAddress(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable UUID addressId) {
+        addressService.deleteAddress(userDetails.getUsername(), addressId);
+        return ApiResponseDto.success(200, "배송지가 삭제되었습니다.", null);
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/address/presentation/controller/AddressControllerDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/address/presentation/controller/AddressControllerDocs.java
@@ -1,0 +1,91 @@
+package com.dfdt.delivery.domain.address.presentation.controller;
+
+import com.dfdt.delivery.common.response.ApiResponseDto;
+import com.dfdt.delivery.domain.address.presentation.dto.AddressRequest;
+import com.dfdt.delivery.domain.address.presentation.dto.AddressResponse;
+import com.dfdt.delivery.domain.auth.infrastructure.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.List;
+import java.util.UUID;
+
+@Tag(name = "Address (배송지)", description = "배송지 등록, 조회, 수정 및 삭제를 담당합니다.")
+public interface AddressControllerDocs {
+
+    @Operation(summary = "API-Address-001 배송지 등록", description = "새로운 배송지를 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "등록 성공"),
+            @ApiResponse(responseCode = "400", description = "입력 형식 오류", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "입력값 검증 실패", value = AddressErrorDocs.INVALID_INPUT_VALUE)
+            })),
+            @ApiResponse(responseCode = "404", description = "지역 정보 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "지역 조회 실패", value = AddressErrorDocs.REGION_NOT_FOUND)
+            }))
+    })
+    ResponseEntity<ApiResponseDto<AddressResponse>> createAddress(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody AddressRequest.Create request);
+
+    @Operation(summary = "API-Address-002 배송지 목록 조회", description = "로그인한 사용자의 모든 배송지 목록을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    ResponseEntity<ApiResponseDto<List<AddressResponse>>> getMyAddresses(
+            @AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "API-Address-003 배송지 상세 조회", description = "특정 배송지의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 부족", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "소유권 없음", value = AddressErrorDocs.ADDRESS_ACCESS_DENIED)
+            })),
+            @ApiResponse(responseCode = "404", description = "배송지 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "배송지 조회 실패", value = AddressErrorDocs.ADDRESS_NOT_FOUND)
+            }))
+    })
+    ResponseEntity<ApiResponseDto<AddressResponse>> getAddress(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            UUID addressId);
+
+    @Operation(summary = "API-Address-004 배송지 수정", description = "기존 배송지 정보를 수정합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공"),
+            @ApiResponse(responseCode = "400", description = "입력 형식 오류", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "입력값 검증 실패", value = AddressErrorDocs.INVALID_INPUT_VALUE)
+            })),
+            @ApiResponse(responseCode = "403", description = "권한 부족", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "소유권 없음", value = AddressErrorDocs.ADDRESS_ACCESS_DENIED)
+            })),
+            @ApiResponse(responseCode = "404", description = "조회 실패", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "배송지 조회 실패", value = AddressErrorDocs.ADDRESS_NOT_FOUND),
+                    @ExampleObject(name = "지역 조회 실패", value = AddressErrorDocs.REGION_NOT_FOUND)
+            }))
+    })
+    ResponseEntity<ApiResponseDto<AddressResponse>> updateAddress(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            UUID addressId,
+            @Valid @RequestBody AddressRequest.Update request);
+
+    @Operation(summary = "API-Address-005 배송지 삭제", description = "배송지를 논리적으로 삭제(Soft Delete)합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 부족", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "소유권 없음", value = AddressErrorDocs.ADDRESS_ACCESS_DENIED)
+            })),
+            @ApiResponse(responseCode = "404", description = "배송지 없음", content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(name = "배송지 조회 실패", value = AddressErrorDocs.ADDRESS_NOT_FOUND)
+            }))
+    })
+    ResponseEntity<ApiResponseDto<Void>> deleteAddress(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            UUID addressId);
+}

--- a/src/main/java/com/dfdt/delivery/domain/address/presentation/controller/AddressErrorDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/address/presentation/controller/AddressErrorDocs.java
@@ -1,0 +1,8 @@
+package com.dfdt.delivery.domain.address.presentation.controller;
+
+public interface AddressErrorDocs {
+    String ADDRESS_NOT_FOUND = "{\"status\": 404, \"errorCode\": \"ADDRESS-001\", \"message\": \"배송지를 찾을 수 없습니다.\"}";
+    String ADDRESS_ACCESS_DENIED = "{\"status\": 403, \"errorCode\": \"ADDRESS-002\", \"message\": \"배송지에 대한 권한이 없습니다.\"}";
+    String REGION_NOT_FOUND = "{\"status\": 404, \"errorCode\": \"REGION-4040\", \"message\": \"해당 Region이 존재하지 않습니다.\"}";
+    String INVALID_INPUT_VALUE = "{\"status\": 400, \"errorCode\": \"INVALID_REQUEST\", \"message\": \"@Valid 형식 에러\"}";
+}

--- a/src/main/java/com/dfdt/delivery/domain/address/presentation/dto/AddressRequest.java
+++ b/src/main/java/com/dfdt/delivery/domain/address/presentation/dto/AddressRequest.java
@@ -1,0 +1,78 @@
+package com.dfdt.delivery.domain.address.presentation.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * 배송지 관련 요청 DTO.
+ * 등록(Create) 및 수정(Update) 시 사용되는 데이터를 정의합니다.
+ */
+public class AddressRequest {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Create {
+
+        @NotNull(message = "지역 정보(regionId)는 필수입니다.")
+        private UUID regionId;
+
+        @Size(max = 50, message = "배송지 이름은 50자 이내여야 합니다.")
+        private String addressName;
+
+        @NotBlank(message = "기본 주소(addressLine1)는 필수입니다.")
+        @Size(max = 255)
+        private String addressLine1;
+
+        @Size(max = 255)
+        private String addressLine2;
+
+        @Size(max = 50)
+        private String receiverName;
+
+        @Size(max = 20)
+        private String receiverPhone;
+
+        private Boolean isDefault;
+
+        @Size(max = 255)
+        private String deliveryMemo;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Update {
+
+        private UUID regionId;
+
+        @Size(max = 50)
+        private String addressName;
+
+        @Size(max = 255)
+        private String addressLine1;
+
+        @Size(max = 255)
+        private String addressLine2;
+
+        @Size(max = 50)
+        private String receiverName;
+
+        @Size(max = 20)
+        private String receiverPhone;
+
+        private Boolean isDefault;
+
+        @Size(max = 255)
+        private String deliveryMemo;
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/address/presentation/dto/AddressResponse.java
+++ b/src/main/java/com/dfdt/delivery/domain/address/presentation/dto/AddressResponse.java
@@ -1,0 +1,41 @@
+package com.dfdt.delivery.domain.address.presentation.dto;
+
+import com.dfdt.delivery.domain.address.domain.entity.Address;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AddressResponse {
+    private UUID addressId;
+    private String username;
+    private UUID regionId;
+    private String addressName;
+    private String addressLine1;
+    private String addressLine2;
+    private String receiverName;
+    private String receiverPhone;
+    private Boolean isDefault;
+    private String deliveryMemo;
+
+    public static AddressResponse from(Address address) {
+        return AddressResponse.builder()
+                .addressId(address.getAddressId())
+                .username(address.getUser().getUsername())
+                .regionId(address.getRegion().getRegionId())
+                .addressName(address.getAddressName())
+                .addressLine1(address.getAddressLine1())
+                .addressLine2(address.getAddressLine2())
+                .receiverName(address.getReceiverName())
+                .receiverPhone(address.getReceiverPhone())
+                .isDefault(address.getIsDefault())
+                .deliveryMemo(address.getDeliveryMemo())
+                .build();
+    }
+}

--- a/src/main/java/com/dfdt/delivery/domain/user/presentation/controller/UserControllerDocs.java
+++ b/src/main/java/com/dfdt/delivery/domain/user/presentation/controller/UserControllerDocs.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 @Tag(name = "User (사용자)", description = "회원가입, 프로필 관리 및 관리자 전용 권한 변경을 담당합니다.")
 public interface UserControllerDocs {
 
-    @Operation(summary = "API-001 회원가입", description = "새로운 사용자를 등록합니다.")
+    @Operation(summary = "API-User-001 회원가입", description = "새로운 사용자를 등록합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "회원가입 성공"),
             @ApiResponse(responseCode = "400", description = "입력 형식 오류", content = @Content(mediaType = "application/json", examples = {
@@ -33,7 +33,7 @@ public interface UserControllerDocs {
     })
     ResponseEntity<ApiResponseDto<UserResponseDto>> signup(@Valid @RequestBody SignupRequestDto requestDto);
 
-    @Operation(summary = "API-002 내 정보 조회", description = "현재 로그인한 사용자의 프로필 정보를 조회합니다.")
+    @Operation(summary = "API-User-002 내 정보 조회", description = "현재 로그인한 사용자의 프로필 정보를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(mediaType = "application/json", examples = {
@@ -43,7 +43,7 @@ public interface UserControllerDocs {
     ResponseEntity<ApiResponseDto<UserResponseDto>> getMyProfile(
             @AuthenticationPrincipal CustomUserDetails userDetails);
 
-    @Operation(summary = "API-003 권한 변경", description = "특정 사용자의 권한을 변경합니다. (MASTER 전용)")
+    @Operation(summary = "API-User-003 권한 변경", description = "특정 사용자의 권한을 변경합니다. (MASTER 전용)")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "변경 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 권한 값", content = @Content(mediaType = "application/json", examples = {
@@ -58,7 +58,7 @@ public interface UserControllerDocs {
             @RequestBody UserRoleUpdateRequestDto requestDto,
             @AuthenticationPrincipal CustomUserDetails adminDetails);
 
-    @Operation(summary = "API-004 회원 탈퇴", description = "현재 로그인한 사용자의 계정을 탈퇴(Soft Delete) 처리합니다.")
+    @Operation(summary = "API-User-004 회원 탈퇴", description = "현재 로그인한 사용자의 계정을 탈퇴(Soft Delete) 처리합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "탈퇴 성공"),
             @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(mediaType = "application/json", examples = {
@@ -68,7 +68,7 @@ public interface UserControllerDocs {
     ResponseEntity<ApiResponseDto<Void>> withdraw(
             @AuthenticationPrincipal CustomUserDetails userDetails);
 
-    @Operation(summary = "API-005 내 정보 수정", description = "현재 로그인한 사용자의 닉네임, 이메일 등을 수정합니다.")
+    @Operation(summary = "API-User-005 내 정보 수정", description = "현재 로그인한 사용자의 닉네임, 이메일 등을 수정합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "수정 성공"),
             @ApiResponse(responseCode = "404", description = "사용자 없음", content = @Content(mediaType = "application/json", examples = {

--- a/src/test/java/com/dfdt/delivery/domain/address/application/service/AddressServiceTest.java
+++ b/src/test/java/com/dfdt/delivery/domain/address/application/service/AddressServiceTest.java
@@ -1,0 +1,189 @@
+package com.dfdt.delivery.domain.address.application.service;
+
+import com.dfdt.delivery.common.exception.BusinessException;
+import com.dfdt.delivery.domain.address.domain.entity.Address;
+import com.dfdt.delivery.domain.address.domain.exception.error.enums.AddressErrorCode;
+import com.dfdt.delivery.domain.address.domain.repository.AddressRepository;
+import com.dfdt.delivery.domain.address.presentation.dto.AddressRequest;
+import com.dfdt.delivery.domain.address.presentation.dto.AddressResponse;
+import com.dfdt.delivery.domain.region.domain.entity.Region;
+import com.dfdt.delivery.domain.region.domain.repository.RegionRepository;
+import com.dfdt.delivery.domain.user.domain.entity.User;
+import com.dfdt.delivery.domain.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AddressService 단위 테스트")
+class AddressServiceTest {
+
+    @InjectMocks
+    private AddressService addressService;
+
+    @Mock
+    private AddressRepository addressRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RegionRepository regionRepository;
+
+    private User user;
+    private Region region;
+    private final String username = "testuser";
+    private final UUID regionId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().username(username).name("테스터").build();
+        region = Region.builder().regionId(regionId).name("광화문").build();
+    }
+
+    @Nested
+    @DisplayName("배송지 등록 테스트")
+    class CreateAddress {
+
+        @Test
+        @DisplayName("성공: 새로운 배송지를 등록한다.")
+        void createAddress_Success() {
+            // given
+            AddressRequest.Create request = AddressRequest.Create.builder()
+                    .regionId(regionId)
+                    .addressLine1("서울시 종로구")
+                    .isDefault(false)
+                    .build();
+
+            given(userRepository.findByUsername(username)).willReturn(Optional.of(user));
+            given(regionRepository.findById(regionId)).willReturn(Optional.of(region));
+
+            Address savedAddress = Address.builder()
+                    .user(user).region(region).addressLine1(request.getAddressLine1()).isDefault(false)
+                    .build();
+            ReflectionTestUtils.setField(savedAddress, "addressId", UUID.randomUUID());
+            given(addressRepository.save(any(Address.class))).willReturn(savedAddress);
+
+            // when
+            AddressResponse response = addressService.createAddress(username, request);
+
+            // then
+            assertThat(response.getAddressLine1()).isEqualTo(request.getAddressLine1());
+            verify(addressRepository, times(1)).save(any(Address.class));
+            verify(addressRepository, never()).findByUserAndIsDefaultTrueAndSoftDeleteAuditDeletedAtIsNull(any());
+        }
+
+        @Test
+        @DisplayName("성공: 기본 배송지로 등록 시 기존 기본 배송지는 일반 배송지로 변경된다.")
+        void createAddress_WithDefault_Success() {
+            // given
+            AddressRequest.Create request = AddressRequest.Create.builder()
+                    .regionId(regionId)
+                    .isDefault(true)
+                    .build();
+
+            Address existingDefault = Address.builder().user(user).isDefault(true).build();
+
+            given(userRepository.findByUsername(username)).willReturn(Optional.of(user));
+            given(regionRepository.findById(regionId)).willReturn(Optional.of(region));
+            given(addressRepository.findByUserAndIsDefaultTrueAndSoftDeleteAuditDeletedAtIsNull(user))
+                    .willReturn(Optional.of(existingDefault));
+
+            Address savedAddress = Address.builder().user(user).region(region).isDefault(true).build();
+            ReflectionTestUtils.setField(savedAddress, "addressId", UUID.randomUUID());
+            given(addressRepository.save(any(Address.class))).willReturn(savedAddress);
+
+            // when
+            addressService.createAddress(username, request);
+
+            // then
+            assertThat(existingDefault.getIsDefault()).isFalse();
+            verify(addressRepository, times(1)).save(any(Address.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("배송지 조회 및 수정 테스트")
+    class UpdateAndDeleteAddress {
+
+        private final UUID addressId = UUID.randomUUID();
+        private Address address;
+
+        @BeforeEach
+        void setUp() {
+            address = Address.builder()
+                    .user(user)
+                    .region(region)
+                    .addressLine1("원래 주소")
+                    .isDefault(false)
+                    .build();
+            ReflectionTestUtils.setField(address, "addressId", addressId);
+        }
+
+        @Test
+        @DisplayName("실패: 소유자가 아닌 사용자가 수정/삭제를 시도하면 예외가 발생한다.")
+        void validateOwner_Fail() {
+            // given
+            String otherUser = "other";
+            given(addressRepository.findByAddressIdAndSoftDeleteAuditDeletedAtIsNull(addressId))
+                    .willReturn(Optional.of(address));
+
+            // when & then
+            assertThatThrownBy(() -> addressService.deleteAddress(otherUser, addressId))
+                    .isInstanceOf(BusinessException.class)
+                    .hasMessageContaining(AddressErrorCode.ADDRESS_ACCESS_DENIED.getMessage());
+        }
+
+        @Test
+        @DisplayName("성공: 배송지를 수정한다.")
+        void updateAddress_Success() {
+            // given
+            AddressRequest.Update request = AddressRequest.Update.builder()
+                    .addressLine1("수정된 주소")
+                    .isDefault(true)
+                    .build();
+
+            given(addressRepository.findByAddressIdAndSoftDeleteAuditDeletedAtIsNull(addressId))
+                    .willReturn(Optional.of(address));
+            given(addressRepository.findByUserAndIsDefaultTrueAndSoftDeleteAuditDeletedAtIsNull(user))
+                    .willReturn(Optional.empty());
+
+            // when
+            AddressResponse response = addressService.updateAddress(username, addressId, request);
+
+            // then
+            assertThat(response.getAddressLine1()).isEqualTo("수정된 주소");
+            assertThat(address.getIsDefault()).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: 배송지를 삭제(Soft Delete)한다.")
+        void deleteAddress_Success() {
+            // given
+            given(addressRepository.findByAddressIdAndSoftDeleteAuditDeletedAtIsNull(addressId))
+                    .willReturn(Optional.of(address));
+
+            // when
+            addressService.deleteAddress(username, addressId);
+
+            // then
+            assertThat(address.getSoftDeleteAudit()).isNotNull();
+            assertThat(address.getSoftDeleteAudit().isDeleted()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
배달 플랫폼의 핵심 기능 중 하나인 배송지(Address) 도메인의 CRUD 기능을 구현.

## ✅ 주요 변경 사항
   - 배송지(Address) 도메인 신규 개발
       - Address 엔티티 구현: Soft Delete 및 Audit 필드 초기화 로직 포함
       - AddressRepository: 도메인 인터페이스와 JPA 구현체(JpaAddressRepository) 분리 아키텍처 적용
       - AddressService: 기본 배송지 자동 전환(Atomic Update), 소유권 검증, Soft Delete 비즈니스 로직 구현
       - AddressController: RESTful API 엔드포인트 구축
   - Swagger API 문서화 및 에러 가이드 추가
       - AddressControllerDocs & AddressErrorDocs: 배송지 API 명세 및 발생 가능한 에러 응답 예시 정의
       - AuthControllerDocs & AuthErrorDocs: 인증 API의 입력값 검증 오류(400) 등에 대한 문서 보완
   - 인프라 및 설정 최적화
       - logback-spring.xml: 로컬 환경에서도 에러 로그를 즉시 확인할 수 있도록 콘솔 출력 설정 개선
       - AddressRequest: 유효성 검증(@Valid) 어노테이션 적용으로 데이터 무결성 강화

## 🧪 테스트 / 확인 방법
   - [x] 로컬 실행 확인: 서버 기동 및 로그 출력 정상 확인
   - [x] 주요 시나리오 동작 확인: AddressServiceTest를 통해 배송지 등록/조회/수정/삭제 시나리오 검증 성공
   - [x] 예외 케이스 확인: 권한 없는 사용자의 접근 차단 및 지역 정보 부재 시 예외 발생 검증 완료

### 확인 방법
   1. ./gradlew test --tests *AddressServiceTest* 실행하여 비즈니스 로직 검증
   2. Swagger UI(http://localhost:8080/swagger) 접속하여 신규 API 명세 확인
   3. Postman을 이용한 실제 배송지 등록 및 기본 배송지 전환 로직 테스트

## ⚠️ 영향 범위
   - [x] API 스펙 변경 (배송지 관련 신규 API 추가)
   - [x] DB 스키마 변경 (p_address 테이블 엔티티 반영)
   - [x] 응답값/에러코드 변경 (AddressErrorCode 신규 추가)
   - [x] 문서(Swagger/README) 수정 ( Address 문서화 인터페이스 추가)