### PR TITLE
fix: AI 도메인 예외 처리 강화 및 주요 흐름 로깅 추가

### DIFF
--- a/src/main/java/com/dfdt/delivery/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dfdt/delivery/common/exception/GlobalExceptionHandler.java
@@ -57,10 +57,17 @@ public class GlobalExceptionHandler {
         return  ErrorResponseDto.fail(CommonErrorCode.METHOD_TYPE_MISMATCH, e.getMessage());
     }
 
+    // IllegalArgumentException — 도메인 객체 내부 방어 검증 실패 (프로그래밍 오류)
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ErrorResponseDto> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.error("잘못된 인자 오류 (프로그래밍 버그 의심) - {}", e.getMessage(), e);
+        return ErrorResponseDto.fail(CommonErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
     // INTERNAL_SERVER_ERROR (500 에러)
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponseDto> handleException(Exception e) {
-        log.error("내부 서버 오류 - {}", e.getMessage());
+        log.error("내부 서버 오류 - {}", e.getMessage(), e);
         return ErrorResponseDto.fail(CommonErrorCode.INTERNAL_SERVER_ERROR, e.getMessage());
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/ApplyDescriptionUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/ApplyDescriptionUseCaseImpl.java
@@ -11,9 +11,11 @@ import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
 import com.dfdt.delivery.domain.user.domain.enums.UserRole;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ApplyDescriptionUseCaseImpl implements ApplyDescriptionUseCase {
@@ -61,6 +63,9 @@ public class ApplyDescriptionUseCaseImpl implements ApplyDescriptionUseCase {
 
         // 8. AiLog에 적용 완료 기록
         aiLog.applyDescription(previousDescription, command.requestedBy());
+
+        log.info("[ApplyDescriptionUseCase] AI 설명 적용 완료 - aiLogId={}, productId={}, requestedBy={}",
+                aiLog.getAiLogId(), aiLog.getProductId(), command.requestedBy());
 
         return new ApplyDescriptionResult(
                 aiLog.getAiLogId(),

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateDescriptionUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateDescriptionUseCaseImpl.java
@@ -14,9 +14,11 @@ import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
 import com.dfdt.delivery.domain.user.domain.enums.UserRole;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GenerateDescriptionUseCaseImpl implements GenerateDescriptionUseCase {
@@ -70,15 +72,18 @@ public class GenerateDescriptionUseCaseImpl implements GenerateDescriptionUseCas
         long startMs = System.currentTimeMillis();
         try {
             rawResponse = geminiClient.generate(finalPrompt);
-        } catch (BusinessException e) {
+        } catch (Exception e) {
             int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
+            String errorCode = (e instanceof BusinessException be)
+                    ? be.getErrorCode().getErrorCode()
+                    : AiErrorCode.EXTERNAL_AI_CALL_FAILED.getErrorCode();
             aiLogRepository.save(AiLogEntity.failureProductDescription(
                     command.storeId(),
                     command.productId(),
                     command.requestedBy(),
                     command.inputPrompt(),
                     finalPrompt,
-                    e.getErrorCode().getErrorCode(),
+                    errorCode,
                     e.getMessage(),
                     modelName,
                     responseTimeMs,
@@ -86,7 +91,9 @@ public class GenerateDescriptionUseCaseImpl implements GenerateDescriptionUseCas
                     toneSnapshot,
                     keywordsSnapshot
             ));
-            throw e;
+            if (e instanceof BusinessException be) throw be;
+            log.error("[GenerateDescriptionUseCase] 예기치 못한 오류 발생: {}", e.getMessage(), e);
+            throw new BusinessException(AiErrorCode.EXTERNAL_AI_CALL_FAILED);
         }
         int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
 

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateImageUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/GenerateImageUseCaseImpl.java
@@ -15,9 +15,11 @@ import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
 import com.dfdt.delivery.domain.user.domain.enums.UserRole;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GenerateImageUseCaseImpl implements GenerateImageUseCase {
@@ -73,15 +75,18 @@ public class GenerateImageUseCaseImpl implements GenerateImageUseCase {
         long startMs = System.currentTimeMillis();
         try {
             imageData = imageGenerationClient.generate(finalPrompt, aspectRatio.getRatio());
-        } catch (BusinessException e) {
+        } catch (Exception e) {
             int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
+            String errorCode = (e instanceof BusinessException be)
+                    ? be.getErrorCode().getErrorCode()
+                    : AiErrorCode.EXTERNAL_AI_CALL_FAILED.getErrorCode();
             aiLogRepository.save(AiLogEntity.failureFoodImageGeneration(
                     command.storeId(),
                     command.productId(),
                     command.requestedBy(),
                     command.prompt(),
                     finalPrompt,
-                    e.getErrorCode().getErrorCode(),
+                    errorCode,
                     e.getMessage(),
                     modelName,
                     responseTimeMs,
@@ -89,7 +94,9 @@ public class GenerateImageUseCaseImpl implements GenerateImageUseCase {
                     null,
                     null
             ));
-            throw e;
+            if (e instanceof BusinessException be) throw be;
+            log.error("[GenerateImageUseCase] 예기치 못한 오류 발생: {}", e.getMessage(), e);
+            throw new BusinessException(AiErrorCode.EXTERNAL_AI_CALL_FAILED);
         }
         int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
 

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/RetryDescriptionUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/RetryDescriptionUseCaseImpl.java
@@ -16,12 +16,14 @@ import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
 import com.dfdt.delivery.domain.user.domain.enums.UserRole;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Arrays;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RetryDescriptionUseCaseImpl implements RetryDescriptionUseCase {
@@ -97,15 +99,18 @@ public class RetryDescriptionUseCaseImpl implements RetryDescriptionUseCase {
         long startMs = System.currentTimeMillis();
         try {
             rawResponse = geminiClient.generate(finalPrompt);
-        } catch (BusinessException e) {
+        } catch (Exception e) {
             int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
+            String errorCode = (e instanceof BusinessException be)
+                    ? be.getErrorCode().getErrorCode()
+                    : AiErrorCode.EXTERNAL_AI_CALL_FAILED.getErrorCode();
             aiLogRepository.save(AiLogEntity.failureProductDescription(
                     command.storeId(),
                     sourceLog.getProductId(),
                     command.requestedBy(),
                     inputPrompt,
                     finalPrompt,
-                    e.getErrorCode().getErrorCode(),
+                    errorCode,
                     e.getMessage(),
                     modelName,
                     responseTimeMs,
@@ -113,7 +118,9 @@ public class RetryDescriptionUseCaseImpl implements RetryDescriptionUseCase {
                     toneSnapshot,
                     keywordsSnapshot
             ));
-            throw e;
+            if (e instanceof BusinessException be) throw be;
+            log.error("[RetryDescriptionUseCase] 예기치 못한 오류 발생: {}", e.getMessage(), e);
+            throw new BusinessException(AiErrorCode.EXTERNAL_AI_CALL_FAILED);
         }
         int responseTimeMs = (int) (System.currentTimeMillis() - startMs);
 

--- a/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/RollbackDescriptionUseCaseImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/application/usecase/RollbackDescriptionUseCaseImpl.java
@@ -11,9 +11,11 @@ import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.store.domain.repository.StoreRepository;
 import com.dfdt.delivery.domain.user.domain.enums.UserRole;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RollbackDescriptionUseCaseImpl implements RollbackDescriptionUseCase {
@@ -65,6 +67,9 @@ public class RollbackDescriptionUseCaseImpl implements RollbackDescriptionUseCas
 
         // 8. AiLog에 롤백 기록
         aiLog.rollback(command.requestedBy());
+
+        log.info("[RollbackDescriptionUseCase] 상품 설명 원복 완료 - aiLogId={}, productId={}, requestedBy={}",
+                aiLog.getAiLogId(), aiLog.getProductId(), command.requestedBy());
 
         return new RollbackDescriptionResult(
                 aiLog.getAiLogId(),

--- a/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/adapter/AiDescriptionPortAdapter.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/adapter/AiDescriptionPortAdapter.java
@@ -6,6 +6,7 @@ import com.dfdt.delivery.domain.ai.domain.enums.AiErrorCode;
 import com.dfdt.delivery.domain.ai.domain.repository.AiLogRepository;
 import com.dfdt.delivery.domain.product.domain.port.AiDescriptionPort;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.UUID;
@@ -14,6 +15,7 @@ import java.util.UUID;
  * Product 도메인의 AiDescriptionPort를 AI 도메인 인프라에서 구현합니다.
  * Product 도메인이 AiLog 엔티티/레포지토리를 직접 참조하지 않도록 중간 역할을 합니다.
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AiDescriptionPortAdapter implements AiDescriptionPort {
@@ -24,22 +26,32 @@ public class AiDescriptionPortAdapter implements AiDescriptionPort {
     public String validateAndLink(UUID aiLogId, UUID storeId, UUID productId,
                                   String previousDescription, String username) {
         AiLogEntity aiLog = aiLogRepository.findById(aiLogId)
-                .orElseThrow(() -> new BusinessException(AiErrorCode.AI_LOG_NOT_FOUND));
+                .orElseThrow(() -> {
+                    log.warn("[AiDescriptionPortAdapter] AI 로그 없음 - aiLogId={}", aiLogId);
+                    return new BusinessException(AiErrorCode.AI_LOG_NOT_FOUND);
+                });
 
         if (!aiLog.getStoreId().equals(storeId)) {
+            log.warn("[AiDescriptionPortAdapter] storeId 불일치 - aiLogId={}, expected={}, actual={}",
+                    aiLogId, storeId, aiLog.getStoreId());
             throw new BusinessException(AiErrorCode.STORE_NOT_FOUND);
         }
         if (Boolean.TRUE.equals(aiLog.getIsApplied())) {
+            log.warn("[AiDescriptionPortAdapter] 이미 적용된 AI 로그 - aiLogId={}", aiLogId);
             throw new BusinessException(AiErrorCode.ALREADY_APPLIED);
         }
         if (aiLog.getProductId() != null) {
+            log.warn("[AiDescriptionPortAdapter] 이미 상품 연결된 AI 로그 - aiLogId={}, productId={}",
+                    aiLogId, aiLog.getProductId());
             throw new BusinessException(AiErrorCode.AI_LOG_PRODUCT_ALREADY_SET);
         }
         if (!Boolean.TRUE.equals(aiLog.getIsSuccess())) {
+            log.warn("[AiDescriptionPortAdapter] 실패한 AI 로그는 적용 불가 - aiLogId={}", aiLogId);
             throw new BusinessException(AiErrorCode.AI_LOG_NOT_APPLICABLE);
         }
 
         aiLog.linkToProduct(productId, previousDescription, username);
+        log.info("[AiDescriptionPortAdapter] AI 로그-상품 연결 완료 - aiLogId={}, productId={}", aiLogId, productId);
         return aiLog.getResponseText();
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiImageWebClient.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiImageWebClient.java
@@ -96,6 +96,11 @@ public class GeminiImageWebClient implements ImageGenerationClient {
             }
 
             JsonNode prediction = predictions.get(0);
+            if (prediction == null || prediction.isMissingNode()) {
+                log.warn("[GeminiImageWebClient] predictions[0]이 null");
+                throw new BusinessException(AiErrorCode.EXTERNAL_AI_EMPTY_RESPONSE);
+            }
+
             String base64Data = prediction.path("bytesBase64Encoded").asText(null);
             String mimeType = prediction.path("mimeType").asText(null);
 

--- a/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiWebClient.java
+++ b/src/main/java/com/dfdt/delivery/domain/ai/infrastructure/client/GeminiWebClient.java
@@ -86,12 +86,13 @@ public class GeminiWebClient implements GeminiClient {
                 throw new BusinessException(AiErrorCode.EXTERNAL_AI_EMPTY_RESPONSE);
             }
 
-            String text = candidates.get(0)
-                    .path("content")
-                    .path("parts")
-                    .get(0)
-                    .path("text")
-                    .asText(null);
+            JsonNode parts = candidates.get(0).path("content").path("parts");
+            if (parts.isMissingNode() || parts.isEmpty()) {
+                log.warn("[GeminiWebClient] 응답에 parts 배열이 없음");
+                throw new BusinessException(AiErrorCode.EXTERNAL_AI_EMPTY_RESPONSE);
+            }
+
+            String text = parts.get(0).path("text").asText(null);
 
             if (text == null || text.isBlank()) {
                 throw new BusinessException(AiErrorCode.EXTERNAL_AI_EMPTY_RESPONSE);

--- a/src/main/java/com/dfdt/delivery/domain/product/infrastructure/adapter/ProductForAiAdapter.java
+++ b/src/main/java/com/dfdt/delivery/domain/product/infrastructure/adapter/ProductForAiAdapter.java
@@ -5,6 +5,7 @@ import com.dfdt.delivery.domain.ai.domain.port.ProductInfo;
 import com.dfdt.delivery.domain.product.domain.entity.Product;
 import com.dfdt.delivery.domain.product.domain.repository.JpaProductRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -14,6 +15,7 @@ import java.util.UUID;
  * AI 도메인의 ProductForAiPort를 Product 도메인 인프라에서 구현합니다.
  * AI 도메인이 Product 엔티티/레포지토리를 직접 참조하지 않도록 중간 역할을 합니다.
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ProductForAiAdapter implements ProductForAiPort {
@@ -22,21 +24,32 @@ public class ProductForAiAdapter implements ProductForAiPort {
 
     @Override
     public Optional<ProductInfo> findActive(UUID productId, UUID storeId) {
-        return productRepository.findByProductIdAndStoreId(productId, storeId)
+        Optional<ProductInfo> result = productRepository.findByProductIdAndStoreId(productId, storeId)
                 .filter(p -> p.getSoftDeleteAudit() == null || !p.getSoftDeleteAudit().isDeleted())
                 .map(p -> new ProductInfo(p.getProductId(), p.getName()));
+
+        if (result.isEmpty()) {
+            log.warn("[ProductForAiAdapter] 활성 상품 없음 - productId={}, storeId={}", productId, storeId);
+        }
+        return result;
     }
 
     @Override
     public Optional<String> applyAiDescription(UUID productId, UUID storeId,
                                                 String aiDescription, String username) {
-        return productRepository.findByProductIdAndStoreId(productId, storeId)
+        Optional<String> result = productRepository.findByProductIdAndStoreId(productId, storeId)
                 .filter(p -> p.getSoftDeleteAudit() == null || !p.getSoftDeleteAudit().isDeleted())
                 .map(product -> {
                     String previous = product.getDescription();
                     product.applyAiDescription(aiDescription, username);
+                    log.info("[ProductForAiAdapter] AI 설명 적용 - productId={}, username={}", productId, username);
                     return previous;
                 });
+
+        if (result.isEmpty()) {
+            log.warn("[ProductForAiAdapter] AI 설명 적용 대상 상품 없음 - productId={}, storeId={}", productId, storeId);
+        }
+        return result;
     }
 
     @Override
@@ -44,7 +57,14 @@ public class ProductForAiAdapter implements ProductForAiPort {
                                       String previousDescription, String username) {
         Optional<Product> optProduct = productRepository.findByProductIdAndStoreId(productId, storeId)
                 .filter(p -> p.getSoftDeleteAudit() == null || !p.getSoftDeleteAudit().isDeleted());
-        optProduct.ifPresent(product -> product.restoreDescription(previousDescription, username));
-        return optProduct.isPresent();
+
+        if (optProduct.isEmpty()) {
+            log.warn("[ProductForAiAdapter] 원복 대상 상품 없음 - productId={}, storeId={}", productId, storeId);
+            return false;
+        }
+
+        optProduct.get().restoreDescription(previousDescription, username);
+        log.info("[ProductForAiAdapter] 상품 설명 원복 완료 - productId={}, username={}", productId, username);
+        return true;
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

## 📌 작업 내용
  AI 도메인 전반의 예외 처리 누락과 로깅 부재를 개선했습니다.
  외부 API 호출 실패 시 실패 로그가 저장되지 않는 버그를 수정하고, 운영 중 문제 추적이 어려웠던 주요 흐름에 로깅을 추가했습니다.

## ✅ 주요 변경 사항

  예외 처리 강화
  - GenerateDescriptionUseCaseImpl, RetryDescriptionUseCaseImpl, GenerateImageUseCaseImpl
    - catch (BusinessException e) → catch (Exception e) 변경
    - RuntimeException 발생 시에도 실패 로그(p_ai_log)가 저장되도록 수정
    - BusinessException이 아닌 예외는 EXTERNAL_AI_CALL_FAILED로 변환 후 rethrow
  - GlobalExceptionHandler
    - IllegalArgumentException 전용 핸들러 추가 (스택 트레이스 포함 로깅)
    - 기존 Exception 핸들러에 스택 트레이스 로깅 추가 (e.getMessage() → e.getMessage(), e)

  JSON 파싱 방어 체크
  - GeminiWebClient: candidates[0].content.parts 빈 배열 isEmpty() 체크 추가 → EXTERNAL_AI_EMPTY_RESPONSE
  - GeminiImageWebClient: predictions[0] null 체크 추가 → EXTERNAL_AI_EMPTY_RESPONSE

  로깅 추가
  - AiDescriptionPortAdapter: 검증 실패(warn) / 연결 완료(info) 로그
  - ProductForAiAdapter: 상품 없음(warn) / 설명 적용·원복 완료(info) 로그
  - ApplyDescriptionUseCaseImpl: AI 설명 적용 완료 info 로그
  - RollbackDescriptionUseCaseImpl: 설명 원복 완료 info 로그

  ---

## 🧪 테스트 / 확인 방법
- [ ] 로컬 실행 확인
- [ ] 주요 시나리오 동작 확인
- [ ] 예외 케이스 확인 (해당 시)

### 확인 방법 (선택)

테스트 클래스 | 케이스 수 | 결과
-- | -- | --
GenerateDescriptionUseCaseImplTest | 8 | 전체 PASS
RetryDescriptionUseCaseImplTest | 9 | 전체 PASS
GenerateImageUseCaseImplTest | 9 | 전체 PASS
ApplyDescriptionUseCaseImplTest | 9 | 전체 PASS
RollbackDescriptionUseCaseImplTest | 8 | 전체 PASS
ProductCommandServiceImplTest | 24 | 전체 PASS

## ⚠️ 영향 범위 (해당 시 체크)
- [ ] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정

## 👀 리뷰 포인트 (선택)
  1. catch (Exception e) 변경 범위 — 외부 API 호출 블록에만 한정했습니다. 검증 로직(storeId 일치, 권한 체크 등)은 변경 전과 동일하게 BusinessException을 그대로 던집니다.
  2. GlobalExceptionHandler 변경이 공통 모듈 — IllegalArgumentException 핸들러와 Exception 핸들러의 스택 트레이스 로깅 추가는 모든 도메인에 영향을 줍니다. 로그 수준(error)과 포맷이 팀 컨벤션에 맞는지 확인 부탁드립니다.
  3. 어댑터 로그 수준 — ProductForAiAdapter와 AiDescriptionPortAdapter에서 상품/로그 조회 실패 시 warn을 사용했습니다. 정상적인 비즈니스 예외(존재하지 않는 ID 요청 등)도 warn으로 찍히는 점 참고 바랍니다.