### PR TITLE
perf: 리뷰 도메인 Redis 캐싱 도입

### DIFF
--- a/src/main/java/com/dfdt/delivery/common/config/RedisConfig.java
+++ b/src/main/java/com/dfdt/delivery/common/config/RedisConfig.java
@@ -1,15 +1,46 @@
 package com.dfdt.delivery.common.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import java.time.Duration;
+
 @Configuration
+@EnableCaching
 public class RedisConfig {
+
+    /**
+     * Java 8 날짜/시간 타입 및 객체 타입 정보를 지원하는 ObjectMapper 설정
+     */
+    private ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule()); // OffsetDateTime 지원
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        // 캐시 데이터의 클래스 정보를 JSON에 포함 (역직렬화 시 타입 변환 에러 방지)
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+                .allowIfBaseType(Object.class)
+                .build();
+        mapper.activateDefaultTyping(ptv, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY);
+
+        return mapper;
+    }
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
@@ -19,11 +50,28 @@ public class RedisConfig {
         // Key 직렬화 (String으로 저장)
         template.setKeySerializer(new StringRedisSerializer());
 
-        // Value 직렬화 (JSON 형태)
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        // Value 직렬화 (JSON 형태, 타입 정보 포함)
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()));
 
         return template;
     }
+
+    /**
+     * Spring Cache 전용 매니저 설정
+     */
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10)) // 기본 데이터 유효 시간: 10분
+                .disableCachingNullValues()      // null 값은 저장하지 않음
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper())));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+
     @Bean
     public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory connectionFactory) {
         RedisMessageListenerContainer container = new RedisMessageListenerContainer();

--- a/src/main/java/com/dfdt/delivery/domain/review/application/service/command/ReviewCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/application/service/command/ReviewCommandServiceImpl.java
@@ -12,6 +12,8 @@ import com.dfdt.delivery.domain.review.presentation.dto.response.ReviewResDto;
 import com.dfdt.delivery.domain.store.domain.entity.Store;
 import com.dfdt.delivery.domain.user.domain.enums.UserRole;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +29,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
 
     @Override
     @Transactional
+    @CacheEvict(value = "storeReviews", allEntries = true)
     public ReviewResDto createReview(String username, ReviewCreateReqDto request) {
 
         // 1. 데이터 조회
@@ -68,6 +71,10 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
 
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = "reviewDetail", key = "#reviewId.toString()"),
+            @CacheEvict(value = "storeReviews", allEntries = true)
+    })
     public ReviewResDto updateReview(UUID reviewId, String username, ReviewUpdateReqDto request) {
 
         // 1. 리뷰 조회
@@ -104,6 +111,10 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
 
     @Override
     @Transactional
+    @Caching(evict = {
+            @CacheEvict(value = "reviewDetail", key = "#reviewId.toString()"),
+            @CacheEvict(value = "storeReviews", allEntries = true)
+    })
     public void deleteReview(UUID reviewId, String username, UserRole role) {
 
         // 1. 리뷰 조회

--- a/src/main/java/com/dfdt/delivery/domain/review/application/service/query/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/review/application/service/query/ReviewQueryServiceImpl.java
@@ -15,6 +15,7 @@ import com.dfdt.delivery.domain.review.presentation.dto.response.ReviewListResDt
 import com.dfdt.delivery.domain.review.presentation.dto.response.ReviewResDto;
 import com.dfdt.delivery.domain.store.domain.entity.Store;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +32,9 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = "storeReviews",
+            key = "#storeId.toString() + ':' + #request.page + ':' + #request.size + ':' + #request.sort",
+            unless = "#result == null")
     public ReviewListResDto getStoreReviews(UUID storeId, StoreReviewSearchReqDto request) {
 
         request.setSize(reviewValidator.validateAndAdjustSize(request.getSize()));
@@ -61,6 +65,7 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
 
     @Override
     @Transactional(readOnly = true)
+    @Cacheable(value = "reviewDetail", key = "#reviewId.toString()", unless = "#result == null")
     public ReviewResDto getReview(UUID reviewId) {
 
         Review review = reviewDataFinder.findReview(reviewId);


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

## 📌 작업 내용
리뷰 조회 캐싱

## ✅ 주요 변경 사항
- @Cacheable을 적용하여 리뷰 단건 및 가게별 리뷰 목록 조회 속도 개선
- RedisCacheManager 및 전용 ObjectMapper 설정을 통한 데이터 직렬화 최적화
- @CacheEvict를 사용하여 리뷰 생성/수정/삭제 시 캐시 정합성 보장

## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인
- [ ] 예외 케이스 확인

## ⚠️ 영향 범위 (해당 시 체크)
- [ ] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정
