### PR TITLE
refactor: find에 비관적 락 적용

### DIFF
--- a/src/main/java/com/dfdt/delivery/domain/payment/application/provider/PaymentDataFinder.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/provider/PaymentDataFinder.java
@@ -20,8 +20,18 @@ public class PaymentDataFinder {
                 .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
     }
 
+    public Payment findPaymentWithLock(UUID paymentId) {
+        return paymentRepository.findByIdWithLock(paymentId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+    }
+
     public Payment findPaymentByOrderId(UUID orderId) {
         return paymentRepository.findByOrderId(orderId)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
+    }
+
+    public Payment findPaymentByOrderIdWithLock(UUID orderId) {
+        return paymentRepository.findByOrderIdWithLock(orderId)
                 .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/application/service/command/PaymentCommandServiceImpl.java
@@ -53,7 +53,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     @Override
     @Transactional
     public void timeoutPayment(UUID orderId) {
-        Payment payment = paymentDataFinder.findPaymentByOrderId(orderId);
+        Payment payment = paymentDataFinder.findPaymentByOrderIdWithLock(orderId);
 
         if (payment.getPaymentStatus() != PaymentStatus.READY) {
             return;
@@ -82,7 +82,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     @Transactional
     public PaymentDetailResDto approvePayment(UUID paymentId, PaymentApproveReqDto reqDto, String username) {
         // 1. 결제 데이터 조회
-        Payment payment = paymentDataFinder.findPayment(paymentId);
+        Payment payment = paymentDataFinder.findPaymentWithLock(paymentId);
 
         // 2. READY 상태일 때만 승인 가능
         paymentValidator.validateApproveCondition(payment);
@@ -126,7 +126,7 @@ public class PaymentCommandServiceImpl implements PaymentCommandService {
     @Transactional
     public PaymentDetailResDto cancelPayment(UUID paymentId, String username) {
         // 1. 결제 데이터 조회
-        Payment payment = paymentDataFinder.findPayment(paymentId);
+        Payment payment = paymentDataFinder.findPaymentWithLock(paymentId);
 
         // 2. 결제 상태 확인 (이미 취소되었거나 실패한 경우 제외)
         paymentValidator.validateCancelStatus(payment);

--- a/src/main/java/com/dfdt/delivery/domain/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/domain/repository/PaymentRepository.java
@@ -9,4 +9,7 @@ public interface PaymentRepository {
     Payment save(Payment payment);
     Optional<Payment> findByOrderId(UUID orderId);
     Optional<Payment> findById(UUID paymentId);
+
+    Optional<Payment> findByIdWithLock(UUID paymentId);
+    Optional<Payment> findByOrderIdWithLock(UUID orderId);
 }

--- a/src/main/java/com/dfdt/delivery/domain/payment/infrastructure/persistence/repository/JpaPaymentRepository.java
+++ b/src/main/java/com/dfdt/delivery/domain/payment/infrastructure/persistence/repository/JpaPaymentRepository.java
@@ -2,11 +2,25 @@ package com.dfdt.delivery.domain.payment.infrastructure.persistence.repository;
 
 import com.dfdt.delivery.domain.payment.domain.entity.Payment;
 import com.dfdt.delivery.domain.payment.domain.repository.PaymentRepository;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface JpaPaymentRepository
         extends JpaRepository<Payment, UUID>, PaymentRepository {
 
+    @Override
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Payment p where p.paymentId = :paymentId")
+    Optional<Payment> findByIdWithLock(@Param("paymentId") UUID paymentId);
+
+    @Override
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Payment p where p.orderId = :orderId")
+    Optional<Payment> findByOrderIdWithLock(@Param("orderId") UUID orderId);
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #

## 📌 작업 내용
 Payment 엔티티 조회 시 비관적 잠금을 적용하여 한 세션에서 상태를 변경하는 동안 다른 세션이 접근하지 못하도록 원자성 보장

## ✅ 주요 변경 사항
- DataFinder withlock 적용

## 🧪 테스트 / 확인 방법
- [x] 로컬 실행 확인
- [x] 주요 시나리오 동작 확인
- [ ] 예외 케이스 확인 (해당 시)

## ⚠️ 영향 범위 (해당 시 체크)
- [ ] API 스펙 변경
- [ ] DB 스키마 변경
- [ ] 응답값/에러코드 변경
- [ ] 환경설정 변경
- [ ] 문서(Swagger/README) 수정
